### PR TITLE
fix transition crash when skipping during a timer

### DIFF
--- a/source/funkin/backend/MusicBeatTransition.hx
+++ b/source/funkin/backend/MusicBeatTransition.hx
@@ -79,7 +79,8 @@ class MusicBeatTransition extends MusicBeatSubstate {
 	public function finish() {
 		if (newState != null)
 			FlxG.switchState(newState);
-		close();
+		else
+			close();
 	}
 
 	public override function destroy() {


### PR DESCRIPTION
Fixes a crash that could happen when skipping a transition while there was an unfinished timer/tween