### PR TITLE
Auto `FlxG.save.bind` when switching mods (so no mods override other mod saves and removes bloat)

### DIFF
--- a/source/funkin/backend/system/MainState.hx
+++ b/source/funkin/backend/system/MainState.hx
@@ -68,5 +68,10 @@ class MainState extends FlxState {
 		}
 
 		CoolUtil.safeAddAttributes('./.temp/', NativeAPI.FileAttribute.HIDDEN);
+
+		
+		// We should save the data in a bind specifically for the mod and not in the hot poge of fucking everything. ( from, LJ )
+		FlxG.save.bind("save-default", 'CodenameEngine/${ModsFolder.currentModFolder.trim()}');
+		FlxG.save.flush();
 	}
 }

--- a/source/funkin/editors/ui/UITextBox.hx
+++ b/source/funkin/editors/ui/UITextBox.hx
@@ -119,12 +119,21 @@ class UITextBox extends UISliceSprite implements IUIFocusable {
 			case END:
 				position = label.text.length;
 			case V:
-				if (modifier == KeyModifier.LEFT_CTRL || modifier == KeyModifier.RIGHT_CTRL) {
-					// paste
-					var data:String = Clipboard.generalClipboard.getData(TEXT_FORMAT);
-					if (data != null)
-						onTextInput(data);
-				}
+				// Hey lj here, fixed copying because before we checked if the modifier was left or right ctrl
+				// but somehow it gave a int outside of the KeyModifier's range :sob:
+				// apparently there is a boolean that just checks for you. yw :D
+
+				// if we are not holding ctrl, ignore
+				if (!modifier.ctrlKey) return;
+				// we pasting
+				var data:String = Clipboard.generalClipboard.getData(TEXT_FORMAT);
+				if (data != null) onTextInput(data);
+			case C:
+				// if we are not holding ctrl, ignore
+				if (!modifier.ctrlKey) return;
+
+				// copying
+				Clipboard.generalClipboard.setData(TEXT_FORMAT, label.text);
 			default:
 				// nothing
 		}


### PR DESCRIPTION
There probably is a better way to do it than just `FlxG.save.bind("save-default", 'CodenameEngine/${ModsFolder.currentModFolder.trim()}');` in `MainState`, though when people download the newest action build they will lose all their saves for mods (example: YTP Invastion) because they relied on `FlxG.save` from CodenameEngine saves.

This won't override the `Options.__save` because they differ from base Flixel's FlxSave, and now I can actually do something niche with this feature that im going to be adding :eyes: