### PR TITLE
[ENHANCEMENT] Prevent accidental selecting when tabbing back in

### DIFF
--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -49,6 +49,10 @@ class Main extends Sprite
 
 	public static var game:FunkinGame;
 
+	/**
+	 * The time since the game was focused last time in seconds.
+	 */
+	public static var timeSinceFocus(get, never):Float;
 	public static var time:Int = 0;
 
 	// You can pretty much ignore everything from here on - your code should go in your states.
@@ -152,6 +156,7 @@ class Main extends Sprite
 		Conductor.init();
 		AudioSwitchFix.init();
 		EventManager.init();
+		FlxG.signals.focusGained.add(onFocus);
 		FlxG.signals.preStateSwitch.add(onStateSwitch);
 		FlxG.signals.postStateSwitch.add(onStateSwitchPost);
 
@@ -190,6 +195,10 @@ class Main extends Sprite
 			{asset: diamond, width: 32, height: 32}, new FlxRect(-200, -200, FlxG.width * 1.4, FlxG.height * 1.4));
 	}
 
+	public static function onFocus() {
+		_tickFocused = FlxG.game.ticks;
+	}
+
 	private static function onStateSwitch() {
 		scaleMode.resetSize();
 	}
@@ -208,5 +217,10 @@ class Main extends Sprite
 		}
 
 		MemoryUtil.clearMajor();
+	}
+
+	private static var _tickFocused:Float = 0;
+	public static function get_timeSinceFocus():Float {
+		return (FlxG.game.ticks - _tickFocused) / 1000;
 	}
 }

--- a/source/funkin/options/OptionsScreen.hx
+++ b/source/funkin/options/OptionsScreen.hx
@@ -15,15 +15,11 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 	public var name:String;
 	public var desc:String;
 
-	var timeSinceFocus:Float = 0; 
-
 	public function new(name:String, desc:String, ?options:Array<OptionType>) {
 		super();
 		this.name = name;
 		this.desc = desc;
 		if (options != null) for(o in options) add(o);
-
-		FlxG.signals.focusGained.add(onFocus);
 	}
 
 	public override function update(elapsed:Float) {
@@ -49,7 +45,7 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 
 		if (members.length > 0) {
 			members[curSelected].selected = true;
-			if (controls.ACCEPT || (FlxG.mouse.justReleased && timeSinceFocus > 0.25))
+			if (controls.ACCEPT || (FlxG.mouse.justReleased && Main.timeSinceFocus > 0.25))
 				members[curSelected].onSelect();
 			if (controls.LEFT_P)
 				members[curSelected].onChangeSelection(-1);
@@ -58,22 +54,10 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 		}
 		if (controls.BACK || FlxG.mouse.justReleasedRight)
 			close();
-
-		if(timeSinceFocus < 1)
-			timeSinceFocus += elapsed;
 	}
 
 	public function close() {
 		onClose(this);
-	}
-
-	public function onFocus() {
-		timeSinceFocus = 0;
-	}
-
-	override public function destroy():Void
-	{
-		FlxG.signals.focusGained.remove(onFocus);
 	}
 
 	public function changeSelection(sel:Int, force:Bool = false) {

--- a/source/funkin/options/OptionsScreen.hx
+++ b/source/funkin/options/OptionsScreen.hx
@@ -15,11 +15,15 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 	public var name:String;
 	public var desc:String;
 
+	var timeSinceFocus:Float = 0; 
+
 	public function new(name:String, desc:String, ?options:Array<OptionType>) {
 		super();
 		this.name = name;
 		this.desc = desc;
 		if (options != null) for(o in options) add(o);
+
+		FlxG.signals.focusGained.add(onFocus);
 	}
 
 	public override function update(elapsed:Float) {
@@ -45,7 +49,7 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 
 		if (members.length > 0) {
 			members[curSelected].selected = true;
-			if (controls.ACCEPT || FlxG.mouse.justReleased)
+			if (controls.ACCEPT || (FlxG.mouse.justReleased && timeSinceFocus > 0.25))
 				members[curSelected].onSelect();
 			if (controls.LEFT_P)
 				members[curSelected].onChangeSelection(-1);
@@ -54,10 +58,22 @@ class OptionsScreen extends FlxTypedSpriteGroup<OptionType> {
 		}
 		if (controls.BACK || FlxG.mouse.justReleasedRight)
 			close();
+
+		if(timeSinceFocus < 1)
+			timeSinceFocus += elapsed;
 	}
 
 	public function close() {
 		onClose(this);
+	}
+
+	public function onFocus() {
+		timeSinceFocus = 0;
+	}
+
+	override public function destroy():Void
+	{
+		FlxG.signals.focusGained.remove(onFocus);
 	}
 
 	public function changeSelection(sel:Int, force:Bool = false) {


### PR DESCRIPTION
This PR prevents accidental selection when tabbing back in. It does this by adding a timeout for a quarter of a second.