### PR TITLE
[ENHANCEMENT/BUGFIX] Freeplay changes BPM with Inst Preview

### DIFF
--- a/source/funkin/menus/FreeplayState.hx
+++ b/source/funkin/menus/FreeplayState.hx
@@ -2,6 +2,7 @@ package funkin.menus;
 
 import funkin.backend.chart.Chart;
 import funkin.backend.chart.ChartData.ChartMetaData;
+import funkin.backend.system.Conductor;
 import haxe.io.Path;
 import openfl.text.TextField;
 import flixel.text.FlxText;
@@ -239,7 +240,11 @@ class FreeplayState extends MusicBeatState
 		autoplayElapsed += elapsed;
 		if (!disableAutoPlay && !songInstPlaying && (autoplayElapsed > timeUntilAutoplay || FlxG.keys.justPressed.SPACE)) {
 			if (curPlayingInst != (curPlayingInst = Paths.inst(songs[curSelected].name, songs[curSelected].difficulties[curDifficulty]))) {
-				var huh:Void->Void = function() FlxG.sound.playMusic(curPlayingInst, 0);
+				var huh:Void->Void = function()
+				{
+					FlxG.sound.playMusic(curPlayingInst, 0);
+					Conductor.changeBPM(songs[curSelected].bpm, songs[curSelected].beatsPerMeasure, songs[curSelected].stepsPerBeat);
+				}
 				if(!disableAsyncLoading) Main.execAsync(huh);
 				else huh();
 			}


### PR DESCRIPTION
This PR makes it so once a Freeplay Inst Preview starts playing, the BPM in Conductor changes. This makes it so the Song Offset metronome and TitleState sync up with it.