### PR TITLE
Fixed a bug where notes (NoteGroup) were not destroyed when StrumLine was destroyed.

### DIFF
--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -292,7 +292,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 		super.destroy();
 		if(startingPos != null)
 			startingPos.put();
-		notes.destroy();
+		notes = FlxDestroyUtil.destroy(notes);
 	}
 
 	/**

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -292,6 +292,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 		super.destroy();
 		if(startingPos != null)
 			startingPos.put();
+		notes.destroy();
 	}
 
 	/**


### PR DESCRIPTION
(I use Google Translate)
