### PR TITLE
fix infinite loop that could happen when deleting a strumline

### DIFF
--- a/source/funkin/editors/charter/Charter.hx
+++ b/source/funkin/editors/charter/Charter.hx
@@ -1158,7 +1158,7 @@ class Charter extends UIState {
 				if (note.strumLineID == strumLineID)
 					selection.remove(note);
 				else i++;
-			}
+			} else i++;
 		}
 	}
 	#end


### PR DESCRIPTION
yea this could happen if you had an event selected