### PR TITLE
openalsoft audio fixes

### DIFF
--- a/alsoft.txt
+++ b/alsoft.txt
@@ -1,0 +1,14 @@
+[general]
+sample-type=float32
+stereo-mode=speakers
+stereo-encoding=panpot
+hrtf=false
+cf_level=0
+resampler=fast_bsinc24
+front-stablizer=false
+output-limiter=false
+volume-adjust=0
+[decoder]
+hq-mode=false
+distance-comp=false
+nfc=false

--- a/project.xml
+++ b/project.xml
@@ -67,6 +67,12 @@
 	<assets path='mods' rename='mods' embed='false'/>
 	<assets path='art/readme.txt' rename='do NOT readme.txt' />
 
+	<!-- OpenAL config -->
+	<section if="desktop">
+		<assets path="alsoft.txt" rename="plugins/alsoft.ini" type="text" if="windows"/>
+		<assets path="alsoft.txt" rename="plugins/alsoft.conf" type="text" unless="windows"/>
+	</section>
+
 	<!-- ______________________________ Haxedefines _____________________________ -->
 
 	<haxeflag name="--macro" value="funkin.backend.system.macros.NewHaxeWarning.warn()" />

--- a/source/funkin/backend/system/modules/ALSoftConfig.hx
+++ b/source/funkin/backend/system/modules/ALSoftConfig.hx
@@ -1,0 +1,31 @@
+package funkin.backend.system.modules;
+
+import haxe.io.Path;
+
+/*
+ * A class that simply points OpenALSoft to a custom configuration file when
+ * the game starts up.
+ *
+ * The config overrides a few global OpenALSoft settings with the aim of
+ * improving audio quality on desktop targets.
+ */
+@:keepInit class ALSoftConfig
+{
+	#if desktop
+	static function __init__():Void
+	{
+		var origin:String = #if hl Sys.getCwd() #else Sys.programPath() #end;
+
+		var configPath:String = Path.directory(Path.withoutExtension(origin));
+		#if windows
+		configPath += "/plugins/alsoft.ini";
+		#elseif mac
+		configPath = Path.directory(configPath) + "/Resources/plugins/alsoft.conf";
+		#else
+		configPath += "/plugins/alsoft.conf";
+		#end
+
+		Sys.putEnv("ALSOFT_CONF", configPath);
+	}
+	#end
+}


### PR DESCRIPTION
just a mirror pr of https://github.com/FunkinCrew/Funkin/pull/3318 and https://github.com/ShadowMario/FNF-PsychEngine/pull/15536

changes some openalsoft config settings via a config file to prevent it from doing virtualization when it detects your device as "headphones", which ruins stereo fullness, especially in lower frequencies

also as a bonus this config disables the limiter + slightly improves audio resampling

sooo with this change the audio should sound just like as if you opened it with a media player app (original quality!!!)

---

<details><summary>example vids (left side is the new audio)</summary>

<br>

https://github.com/user-attachments/assets/171259a1-928d-4389-9a62-afc2c3376665

https://github.com/user-attachments/assets/0cf5511d-8f11-4b5c-bc55-2b0aabd345ab

</details>

these arent the best recordings since rn im using a realtek driver instead of my dac so the eq is kinda fucked up in obs... but the config does work!! you can hear the stereo is more full