### PR TITLE
musicVolume is not speed.... wtf

### DIFF
--- a/source/funkin/game/cutscenes/DialogueCutscene.hx
+++ b/source/funkin/game/cutscenes/DialogueCutscene.hx
@@ -86,7 +86,7 @@ class DialogueCutscene extends Cutscene {
 					callback: node.getAtt('callback'),
 					changeDefAnim: node.getAtt('changeDefAnim'),
 					speed: Std.parseFloat(node.getAtt("speed")).getDefault(0.05),
-					musicVolume: node.has.musicVolume ? (volume = Std.parseFloat(node.att.speed).getDefault(0.8)) : null,
+					musicVolume: node.has.musicVolume ? (volume = Std.parseFloat(node.att.musicVolume).getDefault(0.8)) : null,
 					changeMusic: node.has.changeMusic ? FlxG.sound.load(Paths.music(node.att.changeMusic), volume, true) : null,
 					playSound: node.has.playSound ? FlxG.sound.load(Paths.sound(node.att.playSound)) : null,
 					nextSound: node.has.nextSound ? FlxG.sound.load(Paths.sound(node.att.nextSound)) : null,


### PR DESCRIPTION
fixes funkin.game.cutscenes.DialogueCutscene
if "musicVolume" was present in the current line, it would grab the value of "speed" instead of "musicVolume" and if "speed" wasn't present, it would crash the game

lmao