### PR TITLE
Add `onScriptSetup` in HScript so you can get when a Script is properly intialized.

### DIFF
--- a/source/funkin/backend/scripting/HScript.hx
+++ b/source/funkin/backend/scripting/HScript.hx
@@ -119,6 +119,10 @@ class HScript extends Script {
 			interp.execute(expr);
 			call("new", []);
 		}
+		
+		#if GLOBAL_SCRIPT
+		funkin.backend.scripting.GlobalScript.call("onScriptSetup", [this, "hscript"]);
+		#end
 	}
 
 	public override function reload() {


### PR DESCRIPTION
added `onScriptSetup` so now instead of using `onScriptCreated` in HScript, you can now use this function whent the script is actually initalized!!!! LETS FUCKING GO!!!