### PR TITLE
Fix wmic

### DIFF
--- a/source/funkin/backend/system/framerate/SystemInfo.hx
+++ b/source/funkin/backend/system/framerate/SystemInfo.hx
@@ -49,6 +49,21 @@ class SystemInfo extends FramerateCategory {
 			if (osName != "")
 				osInfo = '${osName} ${osVersion}'.trim();
 		}
+		#elseif windows
+		var windowsCurrentVersionPath = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+		var buildNumber = Std.parseInt(RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "CurrentBuildNumber"));
+		var edition = RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "ProductName");
+		var lcuVersion = RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "LCUVer"); // Last Cumulative Update Version Aka Build Number But Fancy
+
+		if (buildNumber >= 22000) // Windows 11 Initial Release Build Number
+			edition = edition.replace("Windows 10", "Windows 11");
+
+		osInfo = edition;
+
+		if (lcuVersion != null && lcuVersion != "")
+			osInfo += ' ${lcuVersion}';
+		else if (lime.system.System.platformVersion != null && lime.system.System.platformVersion != "")
+			osInfo += ' ${lime.system.System.platformVersion}';
 		#else
 		if (lime.system.System.platformLabel != null && lime.system.System.platformLabel != "" && lime.system.System.platformVersion != null && lime.system.System.platformVersion != "")
 			osInfo = '${lime.system.System.platformLabel.replace(lime.system.System.platformVersion, "").trim()} ${lime.system.System.platformVersion}';

--- a/source/funkin/backend/system/framerate/SystemInfo.hx
+++ b/source/funkin/backend/system/framerate/SystemInfo.hx
@@ -58,10 +58,7 @@ class SystemInfo extends FramerateCategory {
 
 		try {
 			#if windows
-			var process = new HiddenProcess("wmic", ["cpu", "get", "name"]);
-			if (process.exitCode() != 0) throw 'Could not fetch CPU information';
-
-			cpuName = process.stdout.readAll().toString().trim().split("\n")[1].trim();
+			cpuName = RegistryUtil.get(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "ProcessorNameString");
 			#elseif mac
 			var process = new HiddenProcess("sysctl -a | grep brand_string"); // Somehow this isnt able to use the args but it still works
 			if (process.exitCode() != 0) throw 'Could not fetch CPU information';

--- a/source/funkin/backend/system/framerate/SystemInfo.hx
+++ b/source/funkin/backend/system/framerate/SystemInfo.hx
@@ -53,10 +53,14 @@ class SystemInfo extends FramerateCategory {
 		var windowsCurrentVersionPath = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
 		var buildNumber = Std.parseInt(RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "CurrentBuildNumber"));
 		var edition = RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "ProductName");
-		var lcuVersion = RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, "LCUVer"); // Last Cumulative Update Version Aka Build Number But Fancy
 
-		if (buildNumber >= 22000) // Windows 11 Initial Release Build Number
+		var lcuKey = "WinREVersion"; // Last Cumulative Update Key On Older Windows Versions
+		if (buildNumber >= 22000) { // Windows 11 Initial Release Build Number
 			edition = edition.replace("Windows 10", "Windows 11");
+			lcuKey = "LCUVer"; // Last Cumulative Update Key On Windows 11
+		}
+
+		var lcuVersion = RegistryUtil.get(HKEY_LOCAL_MACHINE, windowsCurrentVersionPath, lcuKey);
 
 		osInfo = edition;
 

--- a/source/funkin/backend/utils/MemoryUtil.hx
+++ b/source/funkin/backend/utils/MemoryUtil.hx
@@ -121,7 +121,7 @@ class MemoryUtil {
 		];
 		var memoryOutput:Int = -1;
 
-		var process = new HiddenProcess("wmic", ["memorychip", "get", "SMBIOSMemoryType"]);
+		var process = new HiddenProcess("powershell", ["-Command", "Get-CimInstance Win32_PhysicalMemory | Select-Object -ExpandProperty SMBIOSMemoryType" ]);
 		if (process.exitCode() == 0) memoryOutput = Std.int(Std.parseFloat(process.stdout.readAll().toString().trim().split("\n")[1]));
 		if (memoryOutput != -1) return memoryMap[memoryOutput];
 		#elseif mac

--- a/source/funkin/backend/utils/MemoryUtil.hx
+++ b/source/funkin/backend/utils/MemoryUtil.hx
@@ -92,7 +92,7 @@ class MemoryUtil {
 	public static function getMemType():String {
 		#if windows
 		var memoryMap:Map<Int, String> = [
-			0 => "Unknown",
+			0 => null,
 			1 => "Other",
 			2 => "DRAM",
 			3 => "Synchronous DRAM",
@@ -117,13 +117,23 @@ class MemoryUtil {
 			22 => "DDR2 FB-DIMM",
 			24 => "DDR3",
 			25 => "FBD2",
-			26 => "DDR4"
+			26 => "DDR4",
+			27 => "LPDDR",
+			28 => "LPDDR2",
+			29 => "LPDDR3",
+			30 => "LPDDR4",
+			31 => "Logical Non-volatile device",
+			32 => "HBM",
+			33 => "HBM2",
+			34 => "DDR5",
+			35 => "LPDDR5",
+			36 => "HBM3",
 		];
 		var memoryOutput:Int = -1;
 
 		var process = new HiddenProcess("powershell", ["-Command", "Get-CimInstance Win32_PhysicalMemory | Select-Object -ExpandProperty SMBIOSMemoryType" ]);
 		if (process.exitCode() == 0) memoryOutput = Std.int(Std.parseFloat(process.stdout.readAll().toString().trim().split("\n")[1]));
-		if (memoryOutput != -1) return memoryMap[memoryOutput];
+		if (memoryOutput != -1) return memoryMap[memoryOutput] == null ? 'Unknown ($memoryOutput)' : memoryMap[memoryOutput];
 		#elseif mac
 		var process = new HiddenProcess("system_profiler", ["SPMemoryDataType"]);
 		var reg = ~/Type: (.+)/;

--- a/source/funkin/backend/utils/RegistryUtil.hx
+++ b/source/funkin/backend/utils/RegistryUtil.hx
@@ -27,12 +27,12 @@ class RegistryUtil {
 		std::wstring valname = std::wstring(string.wchar_str());
 
 		result = RegOpenKeyExW((HKEY)reinterpret_cast<HKEY>(static_cast<uintptr_t>(hive)), subkey.c_str(), 0, KEY_READ, &hKey);
-		if (result != ERROR_SUCCESS) return ::String((String)0);
+		if (result != ERROR_SUCCESS) return null();
 
 		result = RegQueryValueExW(hKey, valname.c_str(), NULL, &dataType, NULL, &dataSize);
 		if (result != ERROR_SUCCESS || dataSize == 0) {
 			RegCloseKey(hKey);
-			return (::String)0;
+			return null();
 		}
 
 		std::vector<wchar_t> buffer(dataSize / sizeof(wchar_t));
@@ -42,10 +42,10 @@ class RegistryUtil {
 		if (result == ERROR_SUCCESS) {
 			return ::String(buffer.data());
 		}
-		return (::String)0;
+		return null();
 	')
 	#end
-	public static function get(hive:RegistryHive, key:String, string:String):String
+	public static function get(hive:RegistryHive, key:String, string:String):Null<String>
 	{
 		return null;
 	}

--- a/source/funkin/backend/utils/RegistryUtil.hx
+++ b/source/funkin/backend/utils/RegistryUtil.hx
@@ -1,0 +1,120 @@
+package funkin.backend.utils;
+
+enum abstract RegistryHive(Int) {
+	var HKEY_CLASSES_ROOT = 0x80000000;
+	var HKEY_CURRENT_USER = 0x80000001;
+	var HKEY_LOCAL_MACHINE = 0x80000002;
+	var HKEY_USERS = 0x80000003;
+	var HKEY_CURRENT_CONFIG = 0x80000005;
+}
+#if windows
+@:cppFileCode('
+#include <windows.h>
+#include <tchar.h>
+#include <string>
+#include <vector>
+')
+#end
+class RegistryUtil {
+	#if windows
+	@:functionCode('
+		HKEY hKey;
+		LONG result;
+		DWORD dataSize = 0;
+		DWORD dataType = 0;
+
+		std::wstring subkey = std::wstring(key.wchar_str());
+		std::wstring valname = std::wstring(string.wchar_str());
+
+		result = RegOpenKeyExW((HKEY)reinterpret_cast<HKEY>(static_cast<uintptr_t>(hive)), subkey.c_str(), 0, KEY_READ, &hKey);
+		if (result != ERROR_SUCCESS) return ::String((String)0);
+
+		result = RegQueryValueExW(hKey, valname.c_str(), NULL, &dataType, NULL, &dataSize);
+		if (result != ERROR_SUCCESS || dataSize == 0) {
+			RegCloseKey(hKey);
+			return (::String)0;
+		}
+
+		std::vector<wchar_t> buffer(dataSize / sizeof(wchar_t));
+		result = RegQueryValueExW(hKey, valname.c_str(), NULL, NULL, (LPBYTE)buffer.data(), &dataSize);
+		RegCloseKey(hKey);
+
+		if (result == ERROR_SUCCESS) {
+			return ::String(buffer.data());
+		}
+		return (::String)0;
+	')
+	#end
+	public static function get(hive:RegistryHive, key:String, string:String):String
+	{
+		return null;
+	}
+
+	#if windows
+	@:functionCode('
+		HKEY hKey;
+		LONG result;
+
+		std::wstring subkey = std::wstring(key.wchar_str());
+		std::wstring valname = std::wstring(string.wchar_str());
+		std::wstring data = std::wstring(value.wchar_str());
+
+		result = RegCreateKeyExW((HKEY)reinterpret_cast<HKEY>(static_cast<uintptr_t>(hive)), subkey.c_str(), 0, NULL, 0, KEY_WRITE, NULL, &hKey, NULL);
+		if (result != ERROR_SUCCESS) return false;
+
+		result = RegSetValueExW(hKey, valname.c_str(), 0, REG_SZ, (const BYTE*)data.c_str(), (DWORD)((data.length() + 1) * sizeof(wchar_t)));
+		RegCloseKey(hKey);
+
+		return result == ERROR_SUCCESS;
+	')
+	#end
+	public static function set(hive:RegistryHive, key:String, string:String, value:String):Bool
+	{
+		return false;
+	}
+
+	#if windows
+	@:functionCode('
+		HKEY hKey;
+		LONG result;
+
+		std::wstring subkey = std::wstring(key.wchar_str());
+		std::wstring valname = std::wstring(string.wchar_str());
+
+		result = RegOpenKeyExW((HKEY)reinterpret_cast<HKEY>(static_cast<uintptr_t>(hive)), subkey.c_str(), 0, KEY_READ, &hKey);
+		if (result != ERROR_SUCCESS) return false;
+
+		DWORD dataType = 0;
+		result = RegQueryValueExW(hKey, valname.c_str(), NULL, &dataType, NULL, NULL);
+
+		RegCloseKey(hKey);
+
+		return result == ERROR_SUCCESS;
+	')
+	#end
+	public static function exists(hive:RegistryHive, key:String, string:String):Bool
+	{
+		return false;
+	}
+
+	#if windows
+	@:functionCode('
+		HKEY hKey;
+		LONG result;
+
+		std::wstring subkey = std::wstring(key.wchar_str());
+		std::wstring valname = std::wstring(string.wchar_str());
+
+		result = RegOpenKeyExW((HKEY)reinterpret_cast<HKEY>(static_cast<uintptr_t>(hive)), subkey.c_str(), 0, KEY_SET_VALUE, &hKey);
+		if (result != ERROR_SUCCESS) return false;
+
+		result = RegDeleteValueW(hKey, valname.c_str());
+		RegCloseKey(hKey);
+
+		return result == ERROR_SUCCESS;
+	')
+	#end
+	public static function delete(hive:RegistryHive, key:String, string:String):Bool {
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes the engine getting your cpu name and ram type for the F3 menu and also adds a new class to look into the windows registry (returns `null` and `false` on non windows platforms)
![image](https://github.com/user-attachments/assets/c1bfb6d9-2fd6-4662-8f01-3241644a14b3)
(_i dont really care that im leaking my specs_)

Before any regards the `RegistryUtil` class only has access to what the reg command has on windows so it cant access admin based keys if you don't run the program as admin

**Edit**
Now actually uses the untranslated string of the windows version
![image](https://github.com/user-attachments/assets/447aba2b-0002-4e37-8f11-3d2aad395fe4)