### PR TITLE
fix sound length rounding to seconds

### DIFF
--- a/source/openfl/media/Sound.hx
+++ b/source/openfl/media/Sound.hx
@@ -695,7 +695,7 @@ class Sound extends EventDispatcher
 				// var samples = (__buffer.data.length * 8) / (__buffer.channels * __buffer.bitsPerSample);
 				// return Std.int(samples / __buffer.sampleRate * 1000);
 				var samples = (Int64.make(0, __buffer.data.length) * Int64.ofInt(8)) / Int64.ofInt(__buffer.channels * __buffer.bitsPerSample);
-				var div = Int64.divMod(samples * 1000, Int64.ofInt(__buffer.sampleRate));
+				var div = Int64.divMod(samples * Int64.ofInt(1000), Int64.ofInt(__buffer.sampleRate));
 				var value = (div.quotient + (div.modulus / __buffer.sampleRate));
 				return Int64.toInt(value);
 			}

--- a/source/openfl/media/Sound.hx
+++ b/source/openfl/media/Sound.hx
@@ -695,7 +695,8 @@ class Sound extends EventDispatcher
 				// var samples = (__buffer.data.length * 8) / (__buffer.channels * __buffer.bitsPerSample);
 				// return Std.int(samples / __buffer.sampleRate * 1000);
 				var samples = (Int64.make(0, __buffer.data.length) * Int64.ofInt(8)) / Int64.ofInt(__buffer.channels * __buffer.bitsPerSample);
-				var value = samples / Int64.ofInt(__buffer.sampleRate) * Int64.ofInt(1000);
+				var div = Int64.divMod(samples * 1000, Int64.ofInt(__buffer.sampleRate));
+				var value = (div.quotient + (div.modulus / __buffer.sampleRate));
 				return Int64.toInt(value);
 			}
 			else if (__buffer.__srcVorbisFile != null)


### PR DESCRIPTION
in chart editor songs would end early because guess what.... the sound length was rounded for whatever reason meaning like a 0.9 second song wouldnt even be chartable lmfao

but hopefully its fixed now ..... feel free to test with long ass songs cus that was the whole purpose of changing the sound length stuff in the first place .... i dont have any long ass songs to test .....