### PR TITLE
convert difficulty to lowercase before checking difficulty scripts folder

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -615,7 +615,7 @@ class PlayState extends MusicBeatState
 					// ADD YOUR HARDCODED SCRIPTS HERE!
 				default:
 					var normal = 'songs/${SONG.meta.name.toLowerCase()}/scripts';
-					var scriptsFolders:Array<String> = [normal, normal + '/$difficulty/', 'data/charts/', 'songs/'];
+					var scriptsFolders:Array<String> = [normal, normal + '/${difficulty.toLowerCase()}/', 'data/charts/', 'songs/'];
 
 					for (folder in scriptsFolders) {
 						for (file in Paths.getFolderContent(folder, true, fromMods ? MODS : BOTH)) {


### PR DESCRIPTION
fixes an edge case i ran into while i was testing a mod out on linux. the difficulty scripts didnt load due to the difficulty having capital letters, but still worked on windows since ntfs is case insensitive by default
likely wont break anything since most mods already have the difficulty scripts folder in all lowercase