### PR TITLE
[DOCS] Change `WANRNING` to `WARNING`

### DIFF
--- a/source/funkin/game/Splash.hx
+++ b/source/funkin/game/Splash.hx
@@ -4,7 +4,7 @@ class Splash extends FunkinSprite
 {
 	/**
 	 * The current splash strum
-	 * WANRNING: It can be null
+	 * WARNING: It can be null
 	 */
 	public var strum:Null<Strum>;
 


### PR DESCRIPTION
This PR fixes a spelling mistake of warning in `Splash.hx`.

while im at it,

https://github.com/user-attachments/assets/ec68c6e1-d0ba-47c8-bfca-c9e201618a4f

