### PR TITLE
Fixing the crash handler pop-up for Linux target

### DIFF
--- a/source/funkin/backend/utils/NativeAPI.hx
+++ b/source/funkin/backend/utils/NativeAPI.hx
@@ -171,6 +171,8 @@ class NativeAPI {
 	public static function showMessageBox(caption:String, message:String, icon:MessageBoxIcon = MSG_WARNING) {
 		#if windows
 		Windows.showMessageBox(caption, message, icon);
+		#elseif linux
+		Sys.command('kdialog --title ${caption} --error ${message}'); // Lime's default file and window opener for Linux target fails to load on most Linux distributions because it uses Zenity, so using KDialog should fix a issue
 		#else
 		lime.app.Application.current.window.alert(message, caption);
 		#end


### PR DESCRIPTION
- Most Linux distributions have a issue with opening crash window pop-up because it uses Zenity and it has a weird bug that can cause to class fail open a new window pop-up when you get a crash pop-up and also fails to open file manager (forgot to say that), so using KDialog as fix should help

Now i am gonna show the 2 video examples how it looks using Zenity and KDialog

1. Zenity

https://github.com/user-attachments/assets/869412e9-42aa-44f8-a1f4-03e33bf11fa8

2. KDialog

https://github.com/user-attachments/assets/483b3bed-37b7-4658-9252-654412a2587f

