### PR TITLE
Allow pathBack on Linux (for the 'cne test' command)

### DIFF
--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -81,7 +81,7 @@ class Main extends Sprite
 	public static var audioDisconnected:Bool = false;
 
 	public static var changeID:Int = 0;
-	public static var pathBack = #if windows
+	public static var pathBack = #if (windows || linux)
 			"../../../../"
 		#elseif mac
 			"../../../../../../../"


### PR DESCRIPTION
Pretty much what's on the tin. Sets the asset root to the source assets instead of the exported assets on the Linux build.