### PR TITLE
Fix Inconsistency in Sustain Input

### DIFF
--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -276,30 +276,22 @@ class Note extends FlxSprite
 	public function updateSustain(strum:Strum) {
 		var scrollSpeed = strum.getScrollSpeed(this);
 
-		var len = 0.45 * CoolUtil.quantize(scrollSpeed, 100);
-
-		if (nextSustain != null && lastScrollSpeed != scrollSpeed) {
-			// is long sustain
+		if (lastScrollSpeed != scrollSpeed) {
 			lastScrollSpeed = scrollSpeed;
-
-			scale.y = (sustainLength * len) / frameHeight;
-			updateHitbox();
-			scale.y += gapFix / frameHeight;
+			if (nextSustain != null) {
+				scale.y = (sustainLength * 0.45 * scrollSpeed) / frameHeight;
+				updateHitbox();
+				scale.y += gapFix / frameHeight;
+			}
 		}
 
-		if (!wasGoodHit) return;
-		var t = FlxMath.bound((Conductor.songPosition - strumTime) / (height) * len, 0, 1);
-		var swagRect = this.clipRect == null ? new FlxRect() : this.clipRect;
-		swagRect.x = 0;
-		swagRect.y = t * frameHeight;
-		swagRect.width = frameWidth;
-		swagRect.height = frameHeight;
-
-		setClipRect(swagRect);
+		updateSustainClip();
 	}
 
-	public inline function setClipRect(rect:FlxRect) {
-		this.clipRect = rect;
+	public function updateSustainClip() if (wasGoodHit) {
+		var t = FlxMath.bound((Conductor.songPosition - strumTime) / height * 0.45 * lastScrollSpeed, 0, 1);
+		var rect = clipRect == null ? FlxRect.get() : clipRect;
+		clipRect = rect.set(0, frameHeight * t, frameWidth, frameHeight * (1 - t));
 	}
 
 	@:noCompletion
@@ -315,5 +307,7 @@ class Note extends FlxSprite
 
 	public override function destroy() {
 		super.destroy();
+
+		clipRect = FlxDestroyUtil.put(clipRect);
 	}
 }

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -189,7 +189,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 
 		if (cpu && __updateNote_event.__autoCPUHit && !daNote.avoid && !daNote.wasGoodHit && daNote.strumTime < __updateNote_songPos) PlayState.instance.goodNoteHit(this, daNote);
 
-		if (daNote.wasGoodHit && daNote.isSustainNote && daNote.strumTime + (daNote.sustainLength) < __updateNote_songPos) {
+		if (daNote.wasGoodHit && daNote.isSustainNote && daNote.strumTime + daNote.sustainLength < __updateNote_songPos) {
 			deleteNote(daNote);
 			return;
 		}
@@ -215,8 +215,9 @@ class StrumLine extends FlxTypedGroup<Strum> {
 	var __notePerStrum:Array<Note> = [];
 
 	function __inputProcessPressed(note:Note) {
-		if (__pressed[note.strumID] && note.isSustainNote && note.canBeHit && !note.wasGoodHit) {
+		if (__pressed[note.strumID] && note.isSustainNote && note.strumTime < __updateNote_songPos && !note.wasGoodHit) {
 			PlayState.instance.goodNoteHit(this, note);
+			note.updateSustainClip();
 		}
 	}
 	function __inputProcessJustPressed(note:Note) {


### PR DESCRIPTION
Makes it so Player Input on Sustain as the same as how its supposed to be or how the cpu does it

Before: 
Player hits the sustains and sustain animation ending too early

https://github.com/user-attachments/assets/4763fb10-51e7-4435-b819-faf0a52c230e



After: 
Player hits the sustain and sustain animation in time

https://github.com/user-attachments/assets/4b997151-f170-420b-bc60-faf24526a0e1


