### PR TITLE
Clear Second Layer on `Main.refreshAssets`

### DIFF
--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -183,6 +183,7 @@ class Main extends Sprite
 
 	public static function refreshAssets() {
 		WindowUtils.resetTitle();
+		FunkinCache.instance.clearSecondLayer();
 
 		FlxSoundTray.volumeChangeSFX = Paths.sound('menu/volume');
 		FlxSoundTray.volumeUpChangeSFX = null;


### PR DESCRIPTION
### Note: This PR is based off of #650

This PR clears all cache available when changing a mod, so that `vcr.ttf` can get changed immediately.