### PR TITLE
Fixes minor mistake in calculating whitelisted and blacklisted items to be zipped.

### DIFF
--- a/source/funkin/backend/utils/ZipUtil.hx
+++ b/source/funkin/backend/utils/ZipUtil.hx
@@ -129,9 +129,7 @@ class ZipUtil {
 		@param path Folder path
 		@param prefix (Additional) allows you to set a prefix in the zip itself.
 	**/
-	public static function writeFolderToZip(zip:ZipWriter, path:String, ?prefix:String, ?prog:ZipProgress, ?whitelist:Array<String>):ZipProgress {
-		if (prefix == null) prefix = "";
-		if (whitelist == null) whitelist = [];
+	public static function writeFolderToZip(zip:ZipWriter, path:String, ?prefix:String = "", ?prog:ZipProgress, ?list:Array<String> = [], ?useWhitelist:Bool = true):ZipProgress {
 		if (prog == null) prog = new ZipProgress();
 
 		try {
@@ -152,7 +150,9 @@ class ZipUtil {
 				var zipPath = destPath.join("/");
 				for(e in FileSystem.readDirectory(path)) {
 					// whoever made this && instead of || pls die.. k thanks!! -LJ
-					if (bannedNames.contains(e.toLowerCase()) || !whitelist.contains(e.toLowerCase())) continue;
+					if (bannedNames.contains(e.toLowerCase())) continue;
+					// now you can switch to using blacklist or whitelisting specific files to zip.
+					if ((useWhitelist && list.length > 0) && list.contains(e.toLowerCase()) continue;
 					if (FileSystem.isDirectory('$path/$e')) {
 						// is directory, so loop into that function again
 						for(p in [curPath, destPath]) p.push(e);

--- a/source/funkin/backend/utils/ZipUtil.hx
+++ b/source/funkin/backend/utils/ZipUtil.hx
@@ -151,7 +151,8 @@ class ZipUtil {
 				var path = curPath.join("/");
 				var zipPath = destPath.join("/");
 				for(e in FileSystem.readDirectory(path)) {
-					if (bannedNames.contains(e.toLowerCase()) && !whitelist.contains(e.toLowerCase())) continue;
+					// whoever made this && instead of || pls die.. k thanks!!
+					if (bannedNames.contains(e.toLowerCase()) || !whitelist.contains(e.toLowerCase())) continue;
 					if (FileSystem.isDirectory('$path/$e')) {
 						// is directory, so loop into that function again
 						for(p in [curPath, destPath]) p.push(e);

--- a/source/funkin/backend/utils/ZipUtil.hx
+++ b/source/funkin/backend/utils/ZipUtil.hx
@@ -151,7 +151,7 @@ class ZipUtil {
 				var path = curPath.join("/");
 				var zipPath = destPath.join("/");
 				for(e in FileSystem.readDirectory(path)) {
-					// whoever made this && instead of || pls die.. k thanks!!
+					// whoever made this && instead of || pls die.. k thanks!! -LJ
 					if (bannedNames.contains(e.toLowerCase()) || !whitelist.contains(e.toLowerCase())) continue;
 					if (FileSystem.isDirectory('$path/$e')) {
 						// is directory, so loop into that function again


### PR DESCRIPTION
This code proves my code makes it work:
```
var zipList = [];
var whitelist = ["mods", "addons"];
for (folder in FileSystem.readDirectory("./")) {
    if (ZipUtil.bannedNames.contains(folder.toLowerCase()) || !whitelist.contains(folder.toLowerCase())) continue;
    // if (!whitelist.contains(folder.toLowerCase())) continue;
    zipList.push(folder);
}
```
![image](https://github.com/user-attachments/assets/562d0e96-ed3a-4553-b13e-3044c81b7d6b)
