### PR TITLE
Fix a few README links to minimize redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Codename Engine is a new Friday Night Funkin' Engine aimed at simplifying moddin
 
 ## How to download
 
-Latest builds for the engine can be found in the [Actions](https://github.com/YoshiCrafter29/CodenameEngine/actions) tab.<br>
+Latest builds for the engine can be found in the [Actions](https://github.com/CodenameCrew/CodenameEngine/actions) tab.<br>
 In the future (when the engine won't be a WIP anymore) we're gonna also publish the engine on platforms like Gamebanana; stay tuned!
 
-If you don't have a github account please go onto https://fnf-cne-devs.github.io/ and click the download button for the respective operating system.
+If you don't have a github account please go onto https://codename-engine.com/ and click the download button for the respective operating system.
 
 <details>
   <summary><h2>How to build</h2></summary>


### PR DESCRIPTION
All this pull request does is update a few links in the README documentation to actually point to where they redirect to.

This doesn't really change a lot, but it does reduce the number of redirects when using links by a small amount. The old links were set up to redirect to their newer variants; this has the side effect of being somewhat slower.