### PR TITLE
Not Include "Sys" on non-sys targets

### DIFF
--- a/source/funkin/backend/scripting/Script.hx
+++ b/source/funkin/backend/scripting/Script.hx
@@ -32,7 +32,7 @@ class Script extends FlxBasic implements IFlxDestroyable {
 			"Type"				=> Type,
 			"Date"				=> Date,
 			"Lambda"			=> Lambda,
-			"Sys"				=> Sys,
+			#if sys "Sys"		=> Sys, #end
 
 			// OpenFL & Lime related stuff
 			"Assets"			=> openfl.utils.Assets,


### PR DESCRIPTION
Sets "Sys" class only for sys targets