### PR TITLE
Fix MOD_ICON's misleading config comments

### DIFF
--- a/source/funkin/editors/ModConfigWarning.hx
+++ b/source/funkin/editors/ModConfigWarning.hx
@@ -22,10 +22,11 @@ API_VERSION=1
 DOWNLOAD_LINK="YOUR MOD PAGE LINK HERE"
 
 # Not supported yet
-;MOD_ICON64="path/to/icon64.png"
-;MOD_ICON32="path/to/icon32.png"
-;MOD_ICON16="path/to/icon16.png"
-ICON="path/to/icon.png"
+;MOD_ICON64="path/to/icon64"
+;MOD_ICON32="path/to/icon32"
+;MOD_ICON16="path/to/icon16"
+# The path starts in "Your Mod/Images/", do not add an image extension, it already defaults to png.
+ICON="path/to/icon"
 
 [Flags] # This section doesn\'t apply any prefix.
 DISABLE_WARNING_SCREEN=true


### PR DESCRIPTION
The default config file generated for config.ini tells the user to add the .png extension when its already done, since it uses Paths.image