### PR TITLE
Add Nix shell configuration for compiling using Nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,40 @@
+{ }:
+let
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/c407032be28ca2236f45c49cfb2b8b3885294f7f.tar.gz";
+  }) { };
+
+  libs =
+    with pkgs;
+    [
+      SDL2
+      pkg-config
+      openal
+      alsa-lib
+      libvlc
+      libpulseaudio
+      libGL
+    ]
+    ++ (with xorg; [
+      libX11
+      libXext
+      libXinerama
+      libXi
+      libXrandr
+    ]);
+in
+pkgs.mkShell {
+  packages = with pkgs; [
+    haxe
+    neko
+    libsForQt5.qttools
+  ];
+
+  buildInputs = libs;
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libs;
+
+  shellHook = ''
+    source update.sh
+  '';
+}


### PR DESCRIPTION
This pull request simply adds a Nix development shell configuration in a `shell.nix` file to allow compiling and testing using the [Nix package manager](https://nixos.org/). This is especially useful on **NixOS**, which is hosted alongside Nix.

The added file tells Nix to do the following operations when opening a development shell:

* Download an older tarball of the official Nixpkgs channel for version locking, specifically with Haxe in mind. This tarball is theoretically the first one to contain Haxe 4.2.5.
* Install a list of libraries:
  * SDL2
  * pkg-config
  * openal
  * alsa-lib (Both OpenAL and alsa-lib are installed in order to prevent the system from using OSS for audio, which is a no-go on NixOS because it doesn't contain the typical packages that are used for emulating OSS...and also because OSS is practically deprecated nowadays.)
  * libvlc (Of course!)
  * libpulseaudio (Lime currently only uses PulseAudio, so the program will hang without this if it's excluded, ESPECIALLY because it's not linked.)
  * libGL
  * Various natural X11 libraries. These can be seen by checking the second half of the `libs` variable.
* Installs Haxe and Neko. For good measure, this also installs `libsForQt5.qttools`, which is the package for qttools available in this tarball.
* Configure `LD_LIBRARY_PATH` to use the proper library paths, since Lime apparently checks this environment variable for additional libraries *explicitly*. This also includes SDL2.
* `source`s the update script in the shell hook, which is run on startup of the development shell.

Do note that, although Nix supports macOS *natively*, I am unable to test it because I do not have a macOS device of any kind of my own.

Additionally, the Nix shell configuration is intended for me to compile for another pull request, which I will create in due time. However, that branch will have the main branch of my contribution fork as the ancestor, so no commits from this branch will be used.