### PR TITLE
More Accurate VocalsResync

### DIFF
--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1418,7 +1418,7 @@ class PlayState extends MusicBeatState
 
 
 			// abs
-			if (__vocalOffsetTimer * __vocalOffsetTimer > 100) // +-10ms
+			if (__vocalOffsetTimer * __vocalOffsetTimer > 64) // +-8ms
 			{
 				// trace('ResyncVocals - OffsetTimer: ' + __vocalOffsetTimer);
 				__vocalOffsetTimer = 0;


### PR DESCRIPTION
I've found that the current detection mechanism for ResyncVocals seems to have issues—it rarely triggers resynchronization when the audio timing desyncs. That's why I've rewritten a better version that ensures vocals can be effectively resynchronized.