### PR TITLE
Use sh alternatives and fix change directory in building shell scripts

### DIFF
--- a/building/cne-unix.sh
+++ b/building/cne-unix.sh
@@ -1,2 +1,3 @@
-cd "$(dirname "$(cd "$(dirname "$0")" && pwd)")"
+#!/usr/bin/env sh
+cd ..
 haxe -cp commandline -D analyzer-optimize --run Main $@

--- a/building/setup-unix.sh
+++ b/building/setup-unix.sh
@@ -1,2 +1,3 @@
-cd "$(dirname "$(cd "$(dirname "$0")" && pwd)")"
+#!/usr/bin/env sh
+cd ..
 haxe -cp commandline -D analyzer-optimize --run Main setup


### PR DESCRIPTION
This pull request changes the shell scripts to now use shebangs and to safely change the working directory.

The shebangs point to `/usr/bin/env`, which is usually required by UNIX operating systems to be in that exact location, and uses `sh` as that program's first argument. This forces the program to prefer a `sh` variant in any location; that is, `bash`, `zsh`, and the like.

The lone `cd` line has been changed to simply use `cd ..`. The reason for this is that while the previous version worked, it didn't work *correctly* on occasion. Sometimes, it changed the working directory to `/tmp` instead and not the parent directory. `cd ..` does what that line was theoretically supposed to do, and does it safely.