### PR TITLE
BREAKING CHANGE - Persistent Custom Classes

### DIFF
--- a/assets/songs/stress/scripts/tankmenRun.hx
+++ b/assets/songs/stress/scripts/tankmenRun.hx
@@ -1,16 +1,18 @@
-import flixel.FlxSprite;
+import stage.tank.TankmenBG;
 
-var tankmanRun:Array<TankmenBG> = [];
-var grpTankmanRun:FlxTypedGroup<FlxSprite> = [];
+var tankmanGroup:TankmenGroup = {
+	tankmanPool: [],
+	tankmanRun: [],
+	grpTankmanRun: new FlxTypedGroup<FlxSprite>()
+}
 
 var spawnTimes = []; // [[time, direction]]
-var tankmanPool = [];
 
 function recycleTankman() {
-	if(tankmanPool.length == 0) {
-		return new TankmenBG();
+	if(tankmanGroup.tankmanPool.length == 0) {
+		return new TankmenBG(tankmanGroup);
 	} else {
-		return tankmanPool.shift(); // can be pop but it causes it to be less random
+		return tankmanGroup.tankmanPool.shift(); // can be pop but it causes it to be less random
 	}
 }
 
@@ -22,9 +24,9 @@ function getTankman(data:Array<Float>) {
 }
 
 function postCreate() {
-	grpTankmanRun = new FlxTypedGroup();
-	insert(members.indexOf(gf) - 1, grpTankmanRun);
-	if(inCutscene) grpTankmanRun.visible = false;
+	//grpTankmanRun = new FlxTypedGroup();
+	insert(members.indexOf(gf) - 1, tankmanGroup.grpTankmanRun);
+	if(inCutscene) tankmanGroup.grpTankmanRun.visible = false;
 
 	/*var tempTankman:TankmenBG = recycleTankman();
 	tempTankman.strumTime = 10;
@@ -43,7 +45,7 @@ function postCreate() {
 }
 
 function onStartCountdown() {
-	if(PlayState.instance.seenCutscene) grpTankmanRun.visible = true;
+	if(PlayState.instance.seenCutscene) tankmanGroup.grpTankmanRun.visible = true;
 }
 
 function spawnTankmen() {
@@ -54,96 +56,18 @@ function spawnTankmen() {
 
 		//trace("Spawning Tankman", tankmen.sprite.offset, tankmen.goingRight);
 
-		tankmanRun.push(tankmen);
-		grpTankmanRun.add(tankmen.sprite);
+		tankmanGroup.tankmanRun.push(tankmen);
+		tankmanGroup.grpTankmanRun.add(tankmen.sprite);
 	}
 }
 
 function update(elapsed) {
 	spawnTankmen();
 
-	var length = tankmanRun.length;
+	var length = tankmanGroup.tankmanRun.length;
 	for(i in 0...length) {
 		var reverseIndex = length - i - 1;
-		var tankmen = tankmanRun[reverseIndex];
+		var tankmen = tankmanGroup.tankmanRun[reverseIndex];
 		tankmen.update(elapsed);
-	}
-}
-
-class TankmenBG {
-	var strumTime = 0;
-	var goingRight = false;
-	var tankSpeed = 0.7;
-
-	var endingOffset = null;
-	var sprite = null;
-
-	var killed = false;
-
-	function new() {
-		this.sprite = new FlxSprite();
-		var sprite = this.sprite;
-
-		sprite.frames = Paths.getSparrowAtlas('stages/tank/tankmanKilled1');
-		sprite.antialiasing = true;
-		sprite.animation.addByPrefix('run', 'tankman running', 24, true);
-
-		sprite.animation.play('run');
-
-		sprite.updateHitbox();
-
-		sprite.setGraphicSize(Std.int(sprite.width * 0.8));
-		sprite.updateHitbox();
-	}
-
-	function resetShit(x, y, isGoingRight) {
-		var sprite = this.sprite;
-		sprite.revive();
-		sprite.setPosition(x, y);
-		sprite.offset.set(0, 0);
-		goingRight = isGoingRight;
-		endingOffset = FlxG.random.float(50, 200);
-		tankSpeed = FlxG.random.float(0.6, 1);
-		sprite.animation.remove("shot");
-		sprite.animation.addByPrefix('shot', 'John Shot ' + FlxG.random.int(1, 2), 24, false);
-		sprite.animation.play("run");
-		sprite.animation.curAnim.curFrame = FlxG.random.int(0, sprite.animation.curAnim.numFrames - 1);
-
-		killed = false;
-		sprite.flipX = goingRight;
-	}
-
-	function update(elapsed) {
-		var sprite = this.sprite;
-		sprite.visible = !(sprite.x >= FlxG.width * 1.5 || sprite.x <= FlxG.width * -0.5);
-
-		if (sprite.animation.curAnim.name == 'run')
-		{
-			var endDirection:Float = (FlxG.width * 0.74) + endingOffset;
-
-			if (goingRight) {
-				endDirection = (FlxG.width * 0.02) - endingOffset;
-				sprite.x = (endDirection + (Conductor.songPosition - strumTime) * tankSpeed);
-			}
-			else sprite.x = (endDirection - (Conductor.songPosition - strumTime) * tankSpeed);
-		}
-
-		if (Conductor.songPosition > strumTime)
-		{
-			sprite.animation.play('shot');
-			sprite.animation.finishCallback = function(_) {
-				killed = true;
-				grpTankmanRun.remove(sprite, true);
-				sprite.kill();
-				tankmanPool.push(this);
-				tankmanRun.remove(this);
-			}
-
-			if (goingRight)
-			{
-				sprite.offset.y = 200;
-				sprite.offset.x = 300;
-			}
-		}
 	}
 }

--- a/assets/source/stage/tank/TankmenBG.hx
+++ b/assets/source/stage/tank/TankmenBG.hx
@@ -1,0 +1,86 @@
+package stage.tank;
+
+import funkin.backend.assets.Paths;
+import funkin.backend.system.Conductor;
+
+import flixel.FlxSprite;
+import flixel.FlxG;
+
+class TankmenBG {
+	var strumTime = 0;
+	var goingRight = false;
+	var tankSpeed = 0.7;
+
+	var endingOffset:Float;
+	var sprite:FlxSprite;
+
+	var killed = false;
+
+	var grp:TankmenGroup; // A reference to the group
+
+	function new(grp:TankmenGroup) {
+		this.grp = grp;
+
+		sprite = new FlxSprite();
+
+		sprite.frames = Paths.getSparrowAtlas('stages/tank/tankmanKilled1');
+		sprite.antialiasing = true;
+		sprite.animation.addByPrefix('run', 'tankman running', 24, true);
+
+		sprite.animation.play('run');
+
+		sprite.updateHitbox();
+
+		sprite.setGraphicSize(Std.int(sprite.width * 0.8));
+		sprite.updateHitbox();
+	}
+
+	function resetShit(x:Float, y:Float, isGoingRight:Bool) {
+		sprite.revive();
+		sprite.setPosition(x, y);
+		sprite.offset.set(0, 0);
+		goingRight = isGoingRight;
+		endingOffset = FlxG.random.float(50, 200);
+		tankSpeed = FlxG.random.float(0.6, 1);
+		sprite.animation.remove("shot");
+		sprite.animation.addByPrefix('shot', 'John Shot ' + FlxG.random.int(1, 2), 24, false);
+		sprite.animation.play("run");
+		sprite.animation.curAnim.curFrame = FlxG.random.int(0, sprite.animation.curAnim.numFrames - 1);
+
+		killed = false;
+		sprite.flipX = goingRight;
+	}
+
+	function update(elapsed:Float) {
+		sprite.visible = !(sprite.x >= FlxG.width * 1.5 || sprite.x <= FlxG.width * -0.5);
+
+		if (sprite.animation.curAnim.name == 'run')
+		{
+			var endDirection:Float = (FlxG.width * 0.74) + endingOffset;
+
+			if (goingRight) {
+				endDirection = (FlxG.width * 0.02) - endingOffset;
+				sprite.x = (endDirection + (Conductor.songPosition - strumTime) * tankSpeed);
+			}
+			else sprite.x = (endDirection - (Conductor.songPosition - strumTime) * tankSpeed);
+		}
+
+		if (Conductor.songPosition > strumTime)
+		{
+			sprite.animation.play('shot');
+			sprite.animation.finishCallback = function(_) {
+				killed = true;
+				grp.grpTankmanRun.remove(sprite, true);
+				sprite.kill();
+				grp.tankmanPool.push(this);
+				grp.tankmanRun.remove(this);
+			}
+
+			if (goingRight)
+			{
+				sprite.offset.y = 200;
+				sprite.offset.x = 300;
+			}
+		}
+	}
+}

--- a/source/funkin/backend/system/MainState.hx
+++ b/source/funkin/backend/system/MainState.hx
@@ -96,6 +96,7 @@ class MainState extends FlxState {
 		funkin.backend.scripting.GlobalScript.destroy();
 		#end
 		funkin.backend.scripting.Script.staticVariables.clear();
+		funkin.backend.scripting.HScript.customClasses.clear();
 
 		#if MOD_SUPPORT
 		for (addon in _lowPriorityAddons)


### PR DESCRIPTION
basically, now every created/imported custom class will be available across the mod (like static variables) in favor of static fields.

Duplicated class declarations will be ignored and prints a warning message, so it is recommended to put your classes in `./source`. (Note: you can simplify this by creating `import.hx` on `./data/scripts/` and running `importScript('data/scripts/import')` on `global.hx` to simplify the custom class creation, just like real Haxe :3).

To update the custom class code, you will need to reset the mod, reset the game or you can manually delete the custom class from the map and reimporting it, like this: 
```haxe
__script__.interp.customClasses.remove("MyClass");

import MyClass;
```
or
```haxe
import funkin.backend.scripting.HScript;

HScript.customClasses.remove("MyClass");

import MyClass;
```