### PR TITLE
FlxView3D (Away3D) Optimisation

### DIFF
--- a/source/flx3d/Flx3DCamera.hx
+++ b/source/flx3d/Flx3DCamera.hx
@@ -25,19 +25,25 @@ import flx3d.Flx3DUtil;
 import haxe.io.Path;
 import openfl.Assets;
 #end
-
 import flixel.FlxCamera;
 
-class Flx3DCamera extends FlxCamera {
+class Flx3DCamera extends FlxCamera
+{
 	#if THREE_D_SUPPORT
 	private static var __3DIDS:Int = 0;
 
 	public var view:View3D;
 
 	var meshes:Array<Mesh> = [];
-	public function new(X:Int = 0, Y:Int = 0, Width:Int = 0, Height:Int = 0, DefaultZoom:Float = 1) {
+
+	public function new(X:Int = 0, Y:Int = 0, Width:Int = 0, Height:Int = 0, DefaultZoom:Float = 1)
+	{
 		if (!Flx3DUtil.is3DAvailable())
-			throw "[Flx3DCamera] 3D is not available on this platform. Stages in use: " + Flx3DUtil.getTotal3D() + ", Max stages allowed: " + FlxG.stage.stage3Ds.length + ".";
+			throw "[Flx3DCamera] 3D is not available on this platform. Stages in use: "
+				+ Flx3DUtil.getTotal3D()
+				+ ", Max stages allowed: "
+				+ FlxG.stage.stage3Ds.length
+				+ ".";
 		super(X, Y, Width, Height, DefaultZoom);
 		__cur3DStageID = __3DIDS++;
 
@@ -49,7 +55,8 @@ class Flx3DCamera extends FlxCamera {
 		FlxG.stage.addChild(view);
 	}
 
-	public override function render() {
+	public override function render()
+	{
 		super.render();
 
 		view.x = FlxG.game.x + FlxG.game.scaleX * (flashSprite.x + flashSprite.scaleX * (_scrollRect.x + _scrollRect.scaleX * (_scrollRect.scrollRect.x)));
@@ -65,7 +72,8 @@ class Flx3DCamera extends FlxCamera {
 		view.render();
 	}
 
-	public function addModel(assetPath:String, callback:Asset3DEvent->Void, ?texturePath:String, smoothTexture:Bool = true) {
+	public function addModel(assetPath:String, callback:Asset3DEvent->Void, ?texturePath:String, smoothTexture:Bool = true)
+	{
 		var model = Assets.getBytes(assetPath);
 		if (model == null)
 			throw 'Model at ${assetPath} was not found.';
@@ -79,36 +87,43 @@ class Flx3DCamera extends FlxCamera {
 		if (texturePath != null)
 			material = new TextureMaterial(Cast.bitmapTexture(Assets.getBitmapData(texturePath, true, false)), smoothTexture);
 
-		return loadData(model, context, switch(Path.extension(assetPath).toLowerCase()) {
+		return loadData(model, context, switch (Path.extension(assetPath).toLowerCase())
+		{
 			case "dae": new DAEParser();
 			case "md2": new MD2Parser();
 			case "md5": new MD5MeshParser();
 			case "awd": new AWDParser();
-			default:	new OBJParser();
-		}, (event:Asset3DEvent) -> {
-			if (event.asset != null && event.asset.assetType == Asset3DType.MESH) {
-				var mesh:Mesh = cast event.asset;
-				if (material != null)
-					mesh.material = material;
-				meshes.push(mesh);
-			}
-			callback(event);
-		});
+			default: new OBJParser();
+		}, (event:Asset3DEvent) ->
+			{
+				if (event.asset != null && event.asset.assetType == Asset3DType.MESH)
+				{
+					var mesh:Mesh = cast event.asset;
+					if (material != null)
+						mesh.material = material;
+					meshes.push(mesh);
+				}
+				callback(event);
+			});
 	}
 
 	private var __cur3DStageID:Int;
 	private var _loaders:Map<Asset3DLibraryBundle, AssetLoaderToken> = [];
 
-	private function loadData(data:Dynamic, context:AssetLoaderContext, parser:ParserBase, onAssetCallback:Asset3DEvent->Void):AssetLoaderToken {
+	private function loadData(data:Dynamic, context:AssetLoaderContext, parser:ParserBase, onAssetCallback:Asset3DEvent->Void):AssetLoaderToken
+	{
 		var token:AssetLoaderToken;
 
 		var lib:Asset3DLibraryBundle = Asset3DLibraryBundle.getInstance('Flx3DView-${__cur3DStageID}');
 		token = lib.loadData(data, context, null, parser);
 
-		token.addEventListener(Asset3DEvent.ASSET_COMPLETE, (event:Asset3DEvent) -> {
+		token.addEventListener(Asset3DEvent.ASSET_COMPLETE, (event:Asset3DEvent) ->
+		{
 			// ! Taken from Loader3D https://github.com/openfl/away3d/blob/master/away3d/loaders/Loader3D.hx#L207-L232
-			if (event.type == Asset3DEvent.ASSET_COMPLETE) {
-				var obj:ObjectContainer3D = switch (event.asset.assetType) {
+			if (event.type == Asset3DEvent.ASSET_COMPLETE)
+			{
+				var obj:ObjectContainer3D = switch (event.asset.assetType)
+				{
 					case Asset3DType.LIGHT: expect(event.asset, LightBase);
 					case Asset3DType.CONTAINER: expect(event.asset, ObjectContainer3D);
 					case Asset3DType.MESH: expect(event.asset, Mesh);
@@ -126,25 +141,29 @@ class Flx3DCamera extends FlxCamera {
 				onAssetCallback(event);
 		});
 
-		token.addEventListener(LoaderEvent.RESOURCE_COMPLETE, (_) -> {
+		token.addEventListener(LoaderEvent.RESOURCE_COMPLETE, (_) ->
+		{
 			trace("Loader Finished...");
 		});
 
-		_loaders.set(lib,token);
+		_loaders.set(lib, token);
 
 		return token;
 	}
 
-	override function destroy() {
+	override function destroy()
+	{
 		if (meshes != null)
-			for(mesh in meshes)
+			for (mesh in meshes)
 				mesh.dispose();
 
 		var bundle = Asset3DLibraryBundle.getInstance('Flx3DView-${__cur3DStageID}');
 		bundle.stopAllLoadingSessions();
 		@:privateAccess {
-			if (bundle._loadingSessions != null) {
-				for(load in bundle._loadingSessions) {
+			if (bundle._loadingSessions != null)
+			{
+				for (load in bundle._loadingSessions)
+				{
 					load.dispose();
 				}
 			}
@@ -152,10 +171,12 @@ class Flx3DCamera extends FlxCamera {
 		}
 
 		FlxG.stage.removeChild(view);
-		try {
+		try
+		{
 			view.dispose();
-		} catch(e) {
-
+		}
+		catch (e)
+		{
 		}
 
 		super.destroy();

--- a/source/flx3d/Flx3DView.hx
+++ b/source/flx3d/Flx3DView.hx
@@ -25,20 +25,27 @@ import away3d.utils.Utils.expect;
 #end
 
 // FlxView3D with helpers for easier updating
-class Flx3DView extends FlxView3D {
+class Flx3DView extends FlxView3D
+{
 	#if THREE_D_SUPPORT
 	private static var __3DIDS:Int = 0;
 
 	var meshes:Array<Mesh> = [];
-	public function new(x:Float = 0, y:Float = 0, width:Int = -1, height:Int = -1) {
+
+	public function new(x:Float = 0, y:Float = 0, width:Int = -1, height:Int = -1)
+	{
 		if (!Flx3DUtil.is3DAvailable())
-			throw "[Flx3DView] 3D is not available on this platform. Stages in use: " + Flx3DUtil.getUsed3D() + ", Max stages allowed: " + Flx3DUtil.getTotal3D() + ".";
+			throw "[Flx3DView] 3D is not available on this platform. Stages in use: "
+				+ Flx3DUtil.getUsed3D()
+				+ ", Max stages allowed: "
+				+ Flx3DUtil.getTotal3D()
+				+ ".";
 		super(x, y, width, height);
 		__cur3DStageID = __3DIDS++;
 	}
 
-	public function addModel(assetPath:String, callback:Asset3DEvent->Void, ?texturePath:String, smoothTexture:Bool = true) {
-
+	public function addModel(assetPath:String, callback:Asset3DEvent->Void, ?texturePath:String, smoothTexture:Bool = true)
+	{
 		var model = Assets.getBytes(assetPath);
 		if (model == null)
 			throw 'Model at ${assetPath} was not found.';
@@ -52,37 +59,44 @@ class Flx3DView extends FlxView3D {
 		if (texturePath != null)
 			material = new TextureMaterial(Cast.bitmapTexture(Assets.getBitmapData(texturePath, true, false)), smoothTexture);
 
-		return loadData(model, context, switch(Path.extension(assetPath).toLowerCase()) {
+		return loadData(model, context, switch (Path.extension(assetPath).toLowerCase())
+		{
 			case "dae": new DAEParser();
 			case "md2": new MD2Parser();
 			case "md5": new MD5MeshParser();
 			case "awd": new AWDParser();
-			default:	new OBJParser();
-		}, (event:Asset3DEvent) -> {
-			if (event.asset != null && event.asset.assetType == Asset3DType.MESH) {
-				var mesh:Mesh = cast event.asset;
-				if (material != null)
-					mesh.material = material;
-				meshes.push(mesh);
-			}
-			callback(event);
-		});
+			default: new OBJParser();
+		}, (event:Asset3DEvent) ->
+			{
+				if (event.asset != null && event.asset.assetType == Asset3DType.MESH)
+				{
+					var mesh:Mesh = cast event.asset;
+					if (material != null)
+						mesh.material = material;
+					meshes.push(mesh);
+				}
+				callback(event);
+			});
 	}
 
 	private var __cur3DStageID:Int;
 	private var _loaders:Map<Asset3DLibraryBundle, AssetLoaderToken> = [];
 
-	private function loadData(data:Dynamic, context:AssetLoaderContext, parser:ParserBase, onAssetCallback:Asset3DEvent->Void):AssetLoaderToken {
+	private function loadData(data:Dynamic, context:AssetLoaderContext, parser:ParserBase, onAssetCallback:Asset3DEvent->Void):AssetLoaderToken
+	{
 		var token:AssetLoaderToken;
 
 		var lib:Asset3DLibraryBundle;
 		lib = Asset3DLibraryBundle.getInstance('Flx3DView-${__cur3DStageID}');
 		token = lib.loadData(data, context, null, parser);
 
-		token.addEventListener(Asset3DEvent.ASSET_COMPLETE, (event:Asset3DEvent) -> {
+		token.addEventListener(Asset3DEvent.ASSET_COMPLETE, (event:Asset3DEvent) ->
+		{
 			// ! Taken from Loader3D https://github.com/openfl/away3d/blob/master/away3d/loaders/Loader3D.hx#L207-L232
-			if (event.type == Asset3DEvent.ASSET_COMPLETE) {
-				var obj:ObjectContainer3D = switch (event.asset.assetType) {
+			if (event.type == Asset3DEvent.ASSET_COMPLETE)
+			{
+				var obj:ObjectContainer3D = switch (event.asset.assetType)
+				{
 					case Asset3DType.LIGHT: expect(event.asset, LightBase);
 					case Asset3DType.CONTAINER: expect(event.asset, ObjectContainer3D);
 					case Asset3DType.MESH: expect(event.asset, Mesh);
@@ -100,26 +114,29 @@ class Flx3DView extends FlxView3D {
 				onAssetCallback(event);
 		});
 
-		token.addEventListener(LoaderEvent.RESOURCE_COMPLETE, (_) -> {
+		token.addEventListener(LoaderEvent.RESOURCE_COMPLETE, (_) ->
+		{
 			trace("Loader Finished...");
-
 		});
 
-		_loaders.set(lib,token);
+		_loaders.set(lib, token);
 
 		return token;
 	}
 
-	override function destroy() {
+	override function destroy()
+	{
 		if (meshes != null)
-			for(mesh in meshes)
+			for (mesh in meshes)
 				mesh.dispose();
 
 		var bundle = Asset3DLibraryBundle.getInstance('Flx3DView-${__cur3DStageID}');
 		bundle.stopAllLoadingSessions();
 		@:privateAccess {
-			if (bundle._loadingSessions != null) {
-				for(load in bundle._loadingSessions) {
+			if (bundle._loadingSessions != null)
+			{
+				for (load in bundle._loadingSessions)
+				{
 					load.dispose();
 				}
 			}

--- a/source/flx3d/FlxView3D.hx
+++ b/source/flx3d/FlxView3D.hx
@@ -15,10 +15,6 @@ import flixel.FlxSprite;
  *
  * @author lunarcleint
  * @see https://twitter.com/lunarcleint
- *
- *
- * @author StrawberrySage
- * @see https://twitter.com/StrawberrySage_
  */
 class FlxView3D extends FlxSprite
 {

--- a/source/flx3d/FlxView3D.hx
+++ b/source/flx3d/FlxView3D.hx
@@ -139,22 +139,25 @@ class FlxView3D extends FlxSprite
 
 	@:noCompletion override function draw()
 	{
-		super.draw();
 		if (dirty3D)
 		{
-			view.visible = false;
-			FlxG.stage.addChildAt(view, 0);
+			if (legacyRender) {
+				view.visible = false;
+				FlxG.stage.addChildAt(view, 0);
 
-			var old = FlxG.game.filters;
-			FlxG.game.filters = null;
+				var old = FlxG.game.filters;
+				FlxG.game.filters = null;
 
-			if (legacyRender)
 				view.renderer.queueSnapshot(bmp);
+			}
 			view.render();
 
-			FlxG.game.filters = old;
-			FlxG.stage.removeChild(view);
+			if (legacyRender) {
+				FlxG.game.filters = old;
+				FlxG.stage.removeChild(view);
+			}
 		}
+		super.draw();
 	}
 
 	@:noCompletion override function set_width(newWidth:Float):Float

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -154,40 +154,6 @@ class TextureView3D extends View3D
 		// register that a view has been rendered
 		stage3DProxy.bufferClear = false;
 	}
-
-	// idk if i need this but i'll keep commented in case removing it breaks anything
-	/*private override function updateBackBuffer():Void {
-		// No reason trying to configure back buffer if there is no context available.
-		// Doing this anyway (and relying on _stage3DProxy to cache width/height for
-		// context does get available) means usesSoftwareRendering won't be reliable.
-		if (_stage3DProxy.context3D != null && !_shareContext) {
-			if (_globalWidth > 0 && _globalHeight > 0) {
-				// Backbuffers are limited to 2048x2048 in software mode and
-				// trying to configure the backbuffer to be bigger than that
-				// will throw an error. Capping the value is a graceful way of
-				// avoiding runtime exceptions for developers who are unable
-				// to test their Away3D implementation on screens that are
-				// large enough for this error to ever occur.
-				if (_stage3DProxy.usesSoftwareRendering) {
-					// Even though these checks where already made in the width
-					// and height setters, at that point we couldn't be sure that
-					// the context had even been retrieved and the software flag
-					// thus be reliable. Make checks again.
-					if (_globalWidth > 2048)
-						_globalWidth = 2048;
-					if (_globalHeight > 2048)
-						_globalHeight = 2048;
-				}
-
-				_stage3DProxy.configureBackBuffer(Std.int(_globalWidth), Std.int(_globalHeight), _antiAlias, true);
-				_backBufferInvalid = false;
-			} else {
-				/*var stageBR:Point = new Point(stage.x + stage.stageWidth, stage.y + stage.stageHeight);
-				width = parent != null ? parent.globalToLocal(stageBR).x - _localTLPos.x : stage.stageWidth;
-				height = parent != null ? parent.globalToLocal(stageBR).y - _localTLPos.y : stage.stageHeight;* /
-			}
-		}
-	}*/
 }
 
 class BitmapDataCrashFix extends BitmapData

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -15,60 +15,70 @@ import openfl.display.BitmapData;
 import openfl.events.Event;
 import openfl.geom.Point;
 
-class TextureView3D extends View3D {
+class TextureView3D extends View3D
+{
 	public var bitmap:BitmapData;
+
 	private var _framebuffer:TextureBase = null;
 	private var _initialised:Bool = false;
-	public var addCallback:() -> Void;
-	
-	public override function dispose() @:privateAccess{
-		/*_stage3DProxy._stage3DManager.removeStage3DProxy(_stage3DProxy);
-		_stage3DProxy._stage3DIndex = -1;
-		_stage3DProxy._stage3DManager = null;
-		_stage3DProxy._stage3D = null;*/
+
+	public var onUpdateBitmap:(BitmapData) -> Void;
+
+	public override function dispose() @:privateAccess {
+		// prevents the game from disposing flixel's stage3D/context3D
 		_stage3DProxy = null;
 		super.dispose();
 	}
 
-	private override function set_height(value:Float):Float {
-		if (_height == value) return value;
+	private override function set_height(value:Float):Float
+	{
+		if (_height == value)
+			return value;
 		super.set_height(value);
 		_createFramebuffer();
 		return value;
 	}
-	private override function set_width(value:Float):Float {
-		if (_width == value) return value;
+
+	private override function set_width(value:Float):Float
+	{
+		if (_width == value)
+			return value;
 		super.set_width(value);
 		_createFramebuffer();
 		return value;
 	}
 
 	public function new(scene:Scene3D = null, camera:Camera3D = null, renderer:RendererBase = null, forceSoftware:Bool = false, profile:String = "baseline",
-			contextIndex:Int = -1) {
+			contextIndex:Int = -1)
+	{
 		super(scene, camera, renderer, forceSoftware, profile, contextIndex);
-		
+
 		_stage3DProxy = Stage3DManager.getInstance(FlxG.stage).getStage3DProxy(0);
 		_initialised = true;
 		_createFramebuffer();
 	}
 
-	private function _createFramebuffer() {
-		if (width == 0 || height == 0) return;
-		if (_framebuffer != null) _framebuffer.dispose();
+	private function _createFramebuffer()
+	{
+		if (width == 0 || height == 0)
+			return;
+		if (_framebuffer != null)
+			_framebuffer.dispose();
 		_framebuffer = FlxG.stage.context3D.createRectangleTexture(Std.int(_width), Std.int(_height), BGRA, true);
 		bitmap = BitmapDataCrashFix.fromTextureCrashFix(_framebuffer);
-		addCallback();
+		onUpdateBitmap(bitmap);
 	}
 
 	/**
 	 * Renders the view.
 	 */
-	public override function render():Void 
+	public override function render():Void
 	{
 		Stage3DProxy.drawTriangleCount = 0;
 
 		// if context3D has Disposed by the OS,don't render at this frame
-		if (stage3DProxy.context3D == null || !stage3DProxy.recoverFromDisposal()) {
+		if (stage3DProxy.context3D == null || !stage3DProxy.recoverFromDisposal())
+		{
 			_backBufferInvalid = true;
 			return;
 		}
@@ -80,9 +90,11 @@ class TextureView3D extends View3D {
 		if (_shareContext && _layeredView)
 			stage3DProxy.clearDepthBuffer();
 
-		if (!_parentIsStage) {
+		if (!_parentIsStage)
+		{
 			var globalPos:Point = parent.localToGlobal(_localTLPos);
-			if (_globalPos.x != globalPos.x || _globalPos.y != globalPos.y) {
+			if (_globalPos.x != globalPos.x || _globalPos.y != globalPos.y)
+			{
 				_globalPos = globalPos;
 				_globalPosDirty = true;
 			}
@@ -111,13 +123,15 @@ class TextureView3D extends View3D {
 		if (_depthPrepass)
 			renderDepthPrepass(_entityCollector);
 
-		
 		@:privateAccess _renderer.clearOnRender = !_depthPrepass;
 
-		if (_filter3DRenderer != null && _stage3DProxy.context3D != null) {
+		if (_filter3DRenderer != null && _stage3DProxy.context3D != null)
+		{
 			_renderer.render(_entityCollector, _filter3DRenderer.getMainInputTexture(_stage3DProxy), _rttBufferManager.renderToTextureRect);
 			_filter3DRenderer.render(_stage3DProxy, camera, _depthRender);
-		} else {
+		}
+		else
+		{
 			@:privateAccess _renderer.shareContext = _shareContext;
 			if (_shareContext)
 				_renderer.render(_entityCollector, _framebuffer, _scissorRect);
@@ -125,7 +139,8 @@ class TextureView3D extends View3D {
 				_renderer.render(_entityCollector, _framebuffer);
 		}
 
-		if (!_shareContext) {
+		if (!_shareContext)
+		{
 			stage3DProxy.present();
 
 			// fire collected mouse events
@@ -141,7 +156,6 @@ class TextureView3D extends View3D {
 	}
 
 	// idk if i need this but i'll keep commented in case removing it breaks anything
-
 	/*private override function updateBackBuffer():Void {
 		// No reason trying to configure back buffer if there is no context available.
 		// Doing this anyway (and relying on _stage3DProxy to cache width/height for
@@ -176,11 +190,11 @@ class TextureView3D extends View3D {
 	}*/
 }
 
-
-class BitmapDataCrashFix extends BitmapData {
-	public static function fromTextureCrashFix(texture:TextureBase):BitmapDataCrashFix
-	@:privateAccess {
-		if (texture == null) return null;
+class BitmapDataCrashFix extends BitmapData
+{
+	public static function fromTextureCrashFix(texture:TextureBase):BitmapDataCrashFix @:privateAccess {
+		if (texture == null)
+			return null;
 
 		var bitmapData = new BitmapDataCrashFix(texture.__width, texture.__height, true, 0);
 		bitmapData.readable = false;

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -1,0 +1,215 @@
+package flx3d._internal;
+
+import haxe.CallStack;
+import flixel.FlxG;
+import haxe.Exception;
+import away3d.containers.View3D;
+import away3d.containers.Scene3D;
+import away3d.cameras.Camera3D;
+import away3d.core.render.RendererBase;
+import away3d.core.managers.Stage3DManager;
+import away3d.core.managers.Stage3DProxy;
+import openfl.display3D.textures.TextureBase;
+import openfl.display3D.textures.RectangleTexture;
+import openfl.display.BitmapData;
+import openfl.events.Event;
+import openfl.geom.Point;
+
+// TODO: error when disposing of Stage3DProxy. Possibly related to it using Flixel's stage?
+
+class TextureView3D extends View3D {
+	public var bitmap:BitmapData;
+	private var _framebuffer:TextureBase = null;
+	private var _initialised:Bool = false;
+	public var addCallback:() -> Void;
+	
+	/*private override function onAddedToStage(event:Event):Void
+	{
+		if (_addedToStage)
+			return;
+		super.onAddedToStage(event);
+		trace(_stage3DProxy);
+		_framebuffer = _stage3DProxy.context3D.createRectangleTexture(Std.int(width), Std.int(height), BGRA, true);
+		bitmap = BitmapData.fromTexture(_framebuffer);
+		if (addCallback != null) addCallback();
+	}*/
+
+	public override function dispose() {
+		_stage3DProxy = null;
+		super.dispose();
+	}
+
+	private override function set_height(value:Float):Float {
+		//if (_height == value) return value;
+		trace("height", value);
+		trace("=====set_height CALLSTACK=====");
+		trace(CallStack.toString(CallStack.callStack()));
+		trace("==============================");
+		super.set_height(value);
+		//trace("from: set_height");
+		_createFramebuffer();
+		return value;
+	}
+	private override function set_width(value:Float):Float {
+		//if (value > 2048) throw new Exception("breakpoint");
+		//if (_width == value) return value;
+		trace("width", value);
+		trace("=====set_width CALLSTACK=====");
+		trace(CallStack.toString(CallStack.callStack()));
+		trace("=============================");
+		super.set_width(value);
+		//trace("from: set_width");
+		_createFramebuffer();
+		return value;
+	}
+
+	public function new(scene:Scene3D = null, camera:Camera3D = null, renderer:RendererBase = null, forceSoftware:Bool = false, profile:String = "baseline",
+			contextIndex:Int = -1) {
+		super(scene, camera, renderer, forceSoftware, profile, contextIndex);
+		
+		_stage3DProxy = Stage3DManager.getInstance(FlxG.stage).getStage3DProxy(0);
+		addEventListener(Event.ENTER_FRAME, _tryCreateFramebuffer);
+	}
+
+	public function createFramebuffer() {
+		/*if (!_initialised || width == 0 || height == 0) return;
+		trace(_width, _height);
+		_framebuffer = _stage3DProxy.context3D.createRectangleTexture(Std.int(_width), Std.int(_height), BGRA, true);
+		bitmap = BitmapData.fromTexture(_framebuffer);
+		addCallback();*/
+	}
+
+	private function _createFramebuffer() {
+		if (!_initialised || width == 0 || height == 0) return;
+		trace(_width, _height);
+		_framebuffer = _stage3DProxy.context3D.createRectangleTexture(Std.int(_width), Std.int(_height), BGRA, true);
+		bitmap = BitmapData.fromTexture(_framebuffer);
+		addCallback();
+	}
+
+	private function _tryCreateFramebuffer(event:Event) {
+		if (_initialised) return;
+		if (_stage3DProxy == null) return;
+		if (_stage3DProxy.context3D == null) return;
+		if (_width == 0 || _height == 0) return;
+		
+		_initialised = true;
+		trace("from: _tryCreateFramebuffer");
+		_createFramebuffer();
+		removeEventListener(Event.ENTER_FRAME, _tryCreateFramebuffer);
+	}
+
+	/**
+	 * Renders the view.
+	 */
+	public override function render():Void 
+	{
+		Stage3DProxy.drawTriangleCount = 0;
+
+		// if context3D has Disposed by the OS,don't render at this frame
+		if (stage3DProxy.context3D == null || !stage3DProxy.recoverFromDisposal()) {
+			_backBufferInvalid = true;
+			return;
+		}
+
+		// reset or update render settings
+		if (_backBufferInvalid)
+			updateBackBuffer();
+
+		if (_shareContext && _layeredView)
+			stage3DProxy.clearDepthBuffer();
+
+		if (!_parentIsStage) {
+			var globalPos:Point = parent.localToGlobal(_localTLPos);
+			if (_globalPos.x != globalPos.x || _globalPos.y != globalPos.y) {
+				_globalPos = globalPos;
+				_globalPosDirty = true;
+			}
+		}
+
+		if (_globalPosDirty)
+			updateGlobalPos();
+
+		updateTime();
+
+		updateViewSizeData();
+
+		_entityCollector.clear();
+
+		// collect stuff to render
+		_scene.traversePartitions(_entityCollector);
+
+		// update picking
+		_mouse3DManager.updateCollider(this);
+		_touch3DManager.updateCollider();
+
+		if (_requireDepthRender)
+			renderSceneDepthToTexture(_entityCollector);
+
+		// todo: perform depth prepass after light update and before final render
+		if (_depthPrepass)
+			renderDepthPrepass(_entityCollector);
+
+		
+		@:privateAccess _renderer.clearOnRender = !_depthPrepass;
+
+		if (_filter3DRenderer != null && _stage3DProxy.context3D != null) {
+			_renderer.render(_entityCollector, _filter3DRenderer.getMainInputTexture(_stage3DProxy), _rttBufferManager.renderToTextureRect);
+			_filter3DRenderer.render(_stage3DProxy, camera, _depthRender);
+		} else {
+			@:privateAccess _renderer.shareContext = _shareContext;
+			if (_shareContext)
+				_renderer.render(_entityCollector, _framebuffer, _scissorRect);
+			else
+				_renderer.render(_entityCollector, _framebuffer);
+		}
+
+		if (!_shareContext) {
+			stage3DProxy.present();
+
+			// fire collected mouse events
+			_mouse3DManager.fireMouseEvents();
+			_touch3DManager.fireTouchEvents();
+		}
+
+		// clean up data for this render
+		_entityCollector.cleanUp();
+
+		// register that a view has been rendered
+		stage3DProxy.bufferClear = false;
+	}
+
+	private override function updateBackBuffer():Void {
+		// No reason trying to configure back buffer if there is no context available.
+		// Doing this anyway (and relying on _stage3DProxy to cache width/height for
+		// context does get available) means usesSoftwareRendering won't be reliable.
+		if (_stage3DProxy.context3D != null && !_shareContext) {
+			if (_globalWidth > 0 && _globalHeight > 0) {
+				// Backbuffers are limited to 2048x2048 in software mode and
+				// trying to configure the backbuffer to be bigger than that
+				// will throw an error. Capping the value is a graceful way of
+				// avoiding runtime exceptions for developers who are unable
+				// to test their Away3D implementation on screens that are
+				// large enough for this error to ever occur.
+				if (_stage3DProxy.usesSoftwareRendering) {
+					// Even though these checks where already made in the width
+					// and height setters, at that point we couldn't be sure that
+					// the context had even been retrieved and the software flag
+					// thus be reliable. Make checks again.
+					if (_globalWidth > 2048)
+						_globalWidth = 2048;
+					if (_globalHeight > 2048)
+						_globalHeight = 2048;
+				}
+
+				_stage3DProxy.configureBackBuffer(Std.int(_globalWidth), Std.int(_globalHeight), _antiAlias, true);
+				_backBufferInvalid = false;
+			} else {
+				// no. fuck you.
+				/*var stageBR:Point = new Point(stage.x + stage.stageWidth, stage.y + stage.stageHeight);
+				width = parent != null ? parent.globalToLocal(stageBR).x - _localTLPos.x : stage.stageWidth;
+				height = parent != null ? parent.globalToLocal(stageBR).y - _localTLPos.y : stage.stageHeight;*/
+			}
+		}
+	}
+}

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -24,7 +24,7 @@ class TextureView3D extends View3D
 	public var onUpdateBitmap:(BitmapData) -> Void;
 
 	/**
-	 * Prevents the enging from disposing Flixel's Stage3D/Context3D instance
+	 * Prevents the engine from disposing Flixel's Stage3D/Context3D instance
 	 */
 	public override function dispose() @:privateAccess {
 		_stage3DProxy = null;

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -54,6 +54,7 @@ class TextureView3D extends View3D {
 
 	private function _createFramebuffer() {
 		if (width == 0 || height == 0) return;
+		if (_framebuffer != null) _framebuffer.dispose();
 		_framebuffer = FlxG.stage.context3D.createRectangleTexture(Std.int(_width), Std.int(_height), BGRA, true);
 		bitmap = BitmapDataCrashFix.fromTextureCrashFix(_framebuffer);
 		addCallback();

--- a/source/flx3d/_internal/TextureView3D.hx
+++ b/source/flx3d/_internal/TextureView3D.hx
@@ -20,12 +20,13 @@ class TextureView3D extends View3D
 	public var bitmap:BitmapData;
 
 	private var _framebuffer:TextureBase = null;
-	private var _initialised:Bool = false;
 
 	public var onUpdateBitmap:(BitmapData) -> Void;
 
+	/**
+	 * Prevents the enging from disposing Flixel's Stage3D/Context3D instance
+	 */
 	public override function dispose() @:privateAccess {
-		// prevents the game from disposing flixel's stage3D/context3D
 		_stage3DProxy = null;
 		super.dispose();
 	}
@@ -54,7 +55,6 @@ class TextureView3D extends View3D
 		super(scene, camera, renderer, forceSoftware, profile, contextIndex);
 
 		_stage3DProxy = Stage3DManager.getInstance(FlxG.stage).getStage3DProxy(0);
-		_initialised = true;
 		_createFramebuffer();
 	}
 


### PR DESCRIPTION
This pull request optimises Codename Engine's Away3D implementation by rendering the view directly to a framebuffer, rather than taking a snapshot of the output and loading it onto a BitmapData.
This eliminates a bottleneck which previously caused performance issues which got worse as the view's resolution increased.