### PR TITLE
onPostInputUpdate is now an event

### DIFF
--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -343,7 +343,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			str.updatePlayerInput(__pressed[str.ID], __justPressed[str.ID], __justReleased[str.ID]);
 		});
 
-		PlayState.instance.gameAndCharsCall("onPostInputUpdate");
+		PlayState.instance.gameAndCharsEvent("onPostInputUpdate", event);
 	}
 
 	/**


### PR DESCRIPTION
since it had practically no info passed onto it it was basically useless. but now there is info so now it can actually be used to like get the finalized changes done inside onInputUpdate

## will break mods that do use this function, as a required argument has been added