### PR TITLE
Fix a minor issue in StrumLine

### DIFF
--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -77,8 +77,9 @@ class Note extends FlxSprite
 
 	public var strumID(get, never):Int;
 	private function get_strumID() {
-		var id = noteData % strumLine.members.length;
+		var id = noteData;
 		if (id < 0) id = 0;
+		else if (id >= strumLine.members.length) id = noteData % strumLine.members.length;
 		return id;
 	}
 

--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -77,10 +77,7 @@ class Note extends FlxSprite
 
 	public var strumID(get, never):Int;
 	private function get_strumID() {
-		var id = noteData;
-		if (id < 0) id = 0;
-		else if (id >= strumLine.members.length) id = noteData % strumLine.members.length;
-		return id;
+		return if (noteData < 0) 0; else noteData % strumLine.members.length;
 	}
 
 	public var sustainLength:Float = 0;

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -343,9 +343,8 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			notes.forEachAlive(__inputProcessPressed);
 		}
 
-		forEach(function(str:Strum) {
-			str.updatePlayerInput(__pressed[str.ID], __justPressed[str.ID], __justReleased[str.ID]);
-		});
+		for (i => str in members)
+			str.updatePlayerInput(__pressed[i], __justPressed[i], __justReleased[i]);
 
 		PlayState.instance.gameAndCharsCall("onPostInputUpdate");
 	}

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -343,8 +343,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			notes.forEachAlive(__inputProcessPressed);
 		}
 
-		for (i => str in members)
-			str.updatePlayerInput(__pressed[i], __justPressed[i], __justReleased[i]);
+		for (s in members) s.updatePlayerInput(__pressed[s.ID], __justPressed[s.ID], __justReleased[s.ID]);
 
 		PlayState.instance.gameAndCharsEvent("onPostInputUpdate", event);
 	}

--- a/source/funkin/game/StrumLine.hx
+++ b/source/funkin/game/StrumLine.hx
@@ -343,7 +343,7 @@ class StrumLine extends FlxTypedGroup<Strum> {
 			notes.forEachAlive(__inputProcessPressed);
 		}
 
-		for (s in members) s.updatePlayerInput(__pressed[s.ID], __justPressed[s.ID], __justReleased[s.ID]);
+		for (i => s in members) s.updatePlayerInput(__pressed[i], __justPressed[i], __justReleased[i]);
 
 		PlayState.instance.gameAndCharsEvent("onPostInputUpdate", event);
 	}


### PR DESCRIPTION
Previously, using `str.ID` to read the state might have been inconsistent with the input from the code above:

```haxe
for (i in 0...membersLength) {
    __pressed[i] = members[i].__getPressed(this);
    __justPressed[i] = members[i].__getJustPressed(this);
    __justReleased[i] = members[i].__getJustReleased(this);
}
```

It has now been unified to use the `members` index. Additionally, the new approach may offer better performance.