### PR TITLE
Extend custom class

### DIFF
--- a/source/hscript/Config.hx
+++ b/source/hscript/Config.hx
@@ -5,6 +5,7 @@ class Config {
 	public static final ALLOWED_CUSTOM_CLASSES = [
 		#if !DOCUMENTATION
 		"flixel",
+		"openfl.filters.BitmapFilter",
 
 		"funkin",
 		#if MODCHARTING_FEATURES


### PR DESCRIPTION
Make BitmapFilter overridable by scripts (already verified to work)

Previously, I thought writing `extends BitmapFilter` in a script was invalid, but after extensive testing, it turned out to be a viable approach.

Below is a code example of BitmapFilter:

**BloomFilter.hx**
```haxe
import funkin.backend.shaders.FunkinShader;
import openfl.filters.BitmapFilter;
import openfl.display.BitmapData;
import openfl.display.DisplayObjectRenderer;
import openfl.display.Shader;
import openfl.geom.Point;
import openfl.geom.Rectangle;

class BloomFilter extends BitmapFilter {
	static var blurShader_reduce:FunkinShader = new FunkinShader("...");

	static var blurShader_amplification:FunkinShader = new FunkinShader("...");

	static var blurShader_null:FunkinShader = new FunkinShader("...");

	var textureScale:Float = 0;

	public function new(?scale:Float) {
		super();

		scale ??= 0;
		textureScale = scale;

		__needSecondBitmapData = true;
		__preserveObject = false;
		__numShaderPasses = 2;
		__renderDirty = true;

		if (scale > 0) {
			blurShader_reduce.textureScale = scale;
			blurShader_amplification.textureScale = scale;
		}
	}

	public override function clone():BitmapFilter {
		// var newFilter = new BloomFilter(textureScale);
		return this.superClass;
	}

	override function __applyFilter(bitmapData:BitmapData, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point):BitmapData {
		return sourceBitmapData;
	}

	override function __initShader(renderer:DisplayObjectRenderer, pass:Int, sourceBitmapData:BitmapData):Shader {
		if (textureScale <= 0) return blurShader_null;
		
		if (pass == 0) {
			return blurShader_reduce;
		} else {
			return blurShader_amplification;
		}
	}
}
```

**1.hx**
```haxe
import BloomFilter;

function postCreate() {
	var bloom = new BloomFilter(100);
	var realFilter = bloom.superClass;
	FlxG.camera.setFilters([realFilter]);
}
```