### PR TITLE
add global uistate fallback to allow scripting in non uistates

### DIFF
--- a/source/funkin/editors/ui/UIState.hx
+++ b/source/funkin/editors/ui/UIState.hx
@@ -18,9 +18,11 @@ class UIState extends MusicBeatState {
 	public var curContextMenu:UIContextMenu = null;
 
 	public static var state(get, never):UIState;
+	
+	public static var fallbackState:UIState = null;
 
 	private inline static function get_state()
-		return FlxG.state is UIState ? cast FlxG.state : null;
+		return FlxG.state is UIState ? cast FlxG.state : fallbackState;
 
 	public var buttonHandler:Void->Void = null;
 	public var hoveredSprite:UISprite = null;


### PR DESCRIPTION
workaround for the crashes you would normally get trying to use cne ui in non uistates

example of how to use:
```haxe
import funkin.editors.ui.UIState;
import funkin.editors.ui.UITextBox;

var uiState:UIState;
var uiCamera:FlxCamera;

function create() {
	uiState = new UIState();
	UIState.fallbackState = uiState;
	uiState.create();

	uiCamera = new FlxCamera();
	uiCamera.bgColor = 0;
	FlxG.cameras.add(uiCamera, false);

	//add ui stuff here
	textbox = new UITextBox(100, 100, "text box");
	textbox.cameras = [uiCamera];
	uiState.add(textbox);
}

function destroy() {
	uiState.destroy();
	uiState = null;
	UIState.fallbackState = null;
}

function postUpdate(elapsed) {
	uiState.tryUpdate(elapsed);
	if (PlayState.instance != null) {
		canPause = uiState.currentFocus != null ? !(uiState.currentFocus is UITextBox) : true;
	}
}

function postDraw(elapsed) {
	uiState.draw();
}
```