### PR TITLE
Add mod list sorting system

### DIFF
--- a/source/funkin/backend/assets/ModsFolder.hx
+++ b/source/funkin/backend/assets/ModsFolder.hx
@@ -120,11 +120,7 @@ class ModsFolder {
 
 			sortForge.add(Std.string(sortingOptions.descending ? 1 : 0));
 
-			final modeId:String = switch (sortingOptions.mode) {
-			    case ModSortingMode.CLEAN: "c";
-				case ModSortingMode.ALPHABETICAL: "a";
-			};
-			sortForge.add(modeId);
+			sortForge.add(sortingOptions.mode);
 			
 			final sortForgePure:String = sortForge.toString();
 			final sortForgeHashed:String = haxe.crypto.Sha256.encode(sortForgePure);
@@ -234,14 +230,14 @@ class ModSortingController {
 /**
  * The mods list can be sorted in all of the ways provided by this enum.
  */
-enum ModSortingMode {
+enum abstract ModSortingMode(String) {
     /**
      * Use the original list received from reading the directory. This may depend
      * on the current platform, but remains for legacy purposes.
      */
-    CLEAN;
+    var CLEAN;
     /**
      * The list should be in alphabetical order.
      */
-    ALPHABETICAL;
+    var ALPHABETICAL;
 }

--- a/source/funkin/backend/assets/ModsFolder.hx
+++ b/source/funkin/backend/assets/ModsFolder.hx
@@ -115,8 +115,10 @@ class ModsFolder {
 		
 		if (sortingOptions != null) {
 		    var sortForge:StringBuf = new StringBuf();
-			for (i in mods)
-			    sortForge.add(i);	
+			for (i in mods) {
+			    sortForge.add(i);
+				sortForge.add("::");
+			}
 
 			sortForge.add(Std.string(sortingOptions.descending ? 1 : 0));
 

--- a/source/funkin/backend/assets/ModsFolder.hx
+++ b/source/funkin/backend/assets/ModsFolder.hx
@@ -2,6 +2,8 @@ package funkin.backend.assets;
 
 import flixel.util.FlxSignal.FlxTypedSignal;
 import funkin.backend.system.MainState;
+import funkin.backend.utils.CoolUtil;
+import haxe.ds.StringMap;
 import haxe.io.Path;
 import lime.text.Font;
 import openfl.text.Font as OpenFLFont;
@@ -42,6 +44,8 @@ class ModsFolder {
 	 * Whenever its the first time mods has been reloaded.
 	 */
 	private static var __firstTime:Bool = true;
+	
+	private static var modsListSortCache:StringMap<Array<String>> = new StringMap();
 
 	/**
 	 * Initializes `mods` folder.
@@ -94,7 +98,7 @@ class ModsFolder {
 		#end
 	}
 
-	public static function getModsList():Array<String> {
+	public static function getModsList(?sortingOptions:ModSortingOptions):Array<String> {
 		var mods:Array<String> = [];
 		#if MOD_SUPPORT
 		// Mods directory does not exist yet, create it
@@ -107,6 +111,35 @@ class ModsFolder {
 		for (modFolder in modsList) {
 			if (FileSystem.isDirectory(modsPath + modFolder)) mods.push(modFolder);
 			else if (Flags.ALLOWED_ZIP_EXTENSIONS.contains(Path.extension(modFolder))) mods.push(Path.withoutExtension(modFolder));
+		}
+		
+		if (sortingOptions != null) {
+		    var sortForge:StringBuf = new StringBuf();
+			for (i in mods)
+			    sortForge.add(i);	
+
+			sortForge.add(Std.string(sortingOptions.descending ? 1 : 0));
+
+			final modeId:String = switch (sortingOptions.mode) {
+			    case ModSortingMode.CLEAN: "c";
+				case ModSortingMode.ALPHABETICAL: "a";
+			};
+			sortForge.add(modeId);
+			
+			final sortForgePure:String = sortForge.toString();
+			final sortForgeHashed:String = haxe.crypto.Sha256.encode(sortForgePure);
+
+			if (modsListSortCache.exists(sortForgeHashed))
+			    mods = modsListSortCache.get(sortForgeHashed);
+				if (mods.length > 0 && mods[mods.length - 1] == null) mods.pop();
+			else {
+			    ModSortingController.sort(sortingOptions, mods);
+				Logs.traceColored([
+				    Logs.logText("Caching mod sort forge: "),
+					Logs.logText(sortForgePure, GREEN)
+				], VERBOSE);
+				modsListSortCache.set(sortForgeHashed, mods);
+			}
 		}
 		#end
 		return mods;
@@ -166,4 +199,49 @@ class ModsFolder {
 		return prepareModLibrary(libName, new ZipFolderLibrary(zipPath, libName, modName), force, tag);
 	}
 	#end
+}
+
+/**
+ * Describes how mods should be sorted when getting the mods list.
+ */
+typedef ModSortingOptions = {
+    /**
+     * Whether or not the list should go in descending order (e.g. `[2, 1, 0]`).
+     */
+    var descending:Bool;
+    /**
+     * The sorting mode to use.
+     */
+    var mode:ModSortingMode;
+}
+
+/**
+ * This class performs the actual sorting for the mods list.
+ */
+class ModSortingController {
+    /**
+     * Sort the mods list, according to the provided sorting options.
+     */
+    public static function sort(sortingOptions:ModSortingOptions, list:Array<String>):Void {
+        switch (sortingOptions.mode) {
+            case ModSortingMode.CLEAN: {}
+            case ModSortingMode.ALPHABETICAL: CoolUtil.sortAlphabetically(list);
+        }
+        if (sortingOptions.descending) list.reverse();
+    }
+}
+
+/**
+ * The mods list can be sorted in all of the ways provided by this enum.
+ */
+enum ModSortingMode {
+    /**
+     * Use the original list received from reading the directory. This may depend
+     * on the current platform, but remains for legacy purposes.
+     */
+    CLEAN;
+    /**
+     * The list should be in alphabetical order.
+     */
+    ALPHABETICAL;
 }

--- a/source/funkin/backend/assets/ModsFolder.hx
+++ b/source/funkin/backend/assets/ModsFolder.hx
@@ -45,7 +45,7 @@ class ModsFolder {
 	 */
 	private static var __firstTime:Bool = true;
 	
-	private static var modsListSortCache:StringMap<Array<String>> = new StringMap();
+	@:dox(hide) public static var modsListSortCache:StringMap<Array<String>> = new StringMap();
 
 	/**
 	 * Initializes `mods` folder.
@@ -125,18 +125,13 @@ class ModsFolder {
 			sortForge.add(sortingOptions.mode);
 			
 			final sortForgePure:String = sortForge.toString();
-			final sortForgeHashed:String = haxe.crypto.Sha256.encode(sortForgePure);
 
-			if (modsListSortCache.exists(sortForgeHashed))
-			    mods = modsListSortCache.get(sortForgeHashed);
+			if (modsListSortCache.exists(sortForgePure))
+			    mods = modsListSortCache.get(sortForgePure);
 				if (mods.length > 0 && mods[mods.length - 1] == null) mods.pop();
 			else {
 			    ModSortingController.sort(sortingOptions, mods);
-				Logs.traceColored([
-				    Logs.logText("Caching mod sort forge: "),
-					Logs.logText(sortForgePure, GREEN)
-				], VERBOSE);
-				modsListSortCache.set(sortForgeHashed, mods);
+				modsListSortCache.set(sortForgePure, mods);
 			}
 		}
 		#end

--- a/source/funkin/menus/ModSwitchMenu.hx
+++ b/source/funkin/menus/ModSwitchMenu.hx
@@ -29,7 +29,10 @@ class ModSwitchMenu extends MusicBeatSubstate {
 		bg.alpha = 0;
 		FlxTween.tween(bg, {alpha: 0.5}, 0.25, {ease: FlxEase.cubeOut});
 
-		mods = ModsFolder.getModsList();
+		mods = ModsFolder.getModsList({
+		    descending: false,
+			mode: CLEAN,
+		});
 		mods.push(null);
 
 		alphabets = new FlxTypedGroup<Alphabet>();


### PR DESCRIPTION
The mods list can now be sorted in-engine with a cache to come with it.

From the commit message:

> ModsFolder.getModsList now has an optional parameter to describe the various sorting
> options. Excluding this option produces rather legacy behavior and should be
> backwards-compatible.
> 
> Sorted mod lists get cached under a so-called "sort forge," which writes the key to use
> in the cache. If a cache hit occurs, then ModsFolder.getModsList will use the hit.
> 
> Currently, there is support for ascending/descending order and two modes: clean and
> alphabetical sorting. Clean mode provides legacy behavior using this new system, and
> alphabetical sorting uses CoolUtil to sort the list.
> 
> ModSwitchMenu has been updated to use this new system, but really, the only noticeable
> change should just be additional memory overhead.

The primary use case for this would be for extending the mods switch menu to support multiple sorting options, all while being performant in the long run, especially with larger mods lists. The caching in particular assists in this by avoiding the overuse of sorting, doing so only once.

The system should be able to add more sorting mechanisms easily, just by adding the mode to the main enumerator and adding support for the mode in `ModSortingController`. Of course, this does believe that the raw output of the sort is in ascending order, as descending order takes higher priority. These likely will need to come in succeeding pull requests, though, since (as of writing) I don't have any plans to add additional sorting modes in this pull request.