### PR TITLE
Fix UITextBox to play sounds correctly when using C, V, or X keys

### DIFF
--- a/source/funkin/editors/ui/UITextBox.hx
+++ b/source/funkin/editors/ui/UITextBox.hx
@@ -201,32 +201,41 @@ class UITextBox extends UISliceSprite implements IUIFocusable {
 			case END:
 				position = label.text.length;
 			case V:
-				UIState.playEditorSound(Flags.DEFAULT_EDITOR_PASTE_SOUND);
 				// Hey lj here, fixed copying because before we checked if the modifier was left or right ctrl
 				// but somehow it gave a int outside of the KeyModifier's range :sob:
 				// apparently there is a boolean that just checks for you. yw :D
 
 				// if we are not holding ctrl, ignore
-				if (!modifier.ctrlKey)
+				if (!modifier.ctrlKey) {
+				    UIState.playEditorSound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND);
 					return;
+				}
+
+				UIState.playEditorSound(Flags.DEFAULT_EDITOR_PASTE_SOUND);
+				
 				// we pasting
 				var data:String = Clipboard.generalClipboard.getData(TEXT_FORMAT);
 				if (data != null)
 					onTextInput(data);
 			case C:
-				UIState.playEditorSound(Flags.DEFAULT_EDITOR_COPY_SOUND);
 				// if we are not holding ctrl, ignore
-				if (!modifier.ctrlKey)
+				if (!modifier.ctrlKey) {
+				    UIState.playEditorSound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND);
 					return;
+				}
+
+				UIState.playEditorSound(Flags.DEFAULT_EDITOR_COPY_SOUND);
 
 				// copying
 				Clipboard.generalClipboard.setData(TEXT_FORMAT, label.text);
 			case X:
-				UIState.playEditorSound(Flags.DEFAULT_EDITOR_CUT_SOUND);
-
 				// if we are not holding ctrl, ignore
-				if (!modifier.ctrlKey)
+				if (!modifier.ctrlKey) {
+				    UIState.playEditorSound(Flags.DEFAULT_EDITOR_TEXTTYPE_SOUND);
 					return;
+				}
+
+				UIState.playEditorSound(Flags.DEFAULT_EDITOR_CUT_SOUND);
 
 				// cutting
 				Clipboard.generalClipboard.setData(TEXT_FORMAT, label.text);


### PR DESCRIPTION
From the commit description:

> Specifically, this commit makes it so that the typical editor control sounds only play
> when the control key isn't held. Otherwise, it plays the typing sound.

This is intended to solve #982.