### PR TITLE
Use environment variables to change the Haxe version on both `release` & `debug` easily and set hxcpp compile cache without the "~" symbol

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  HAXE_VERSION: 4.3.7
+  HXCPP_COMPILE_CACHE: ${{ github.workspace }}/.hxcpp_cache
+
 jobs:
   build:
     name: Linux Build
@@ -17,7 +21,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -27,8 +31,6 @@ jobs:
             .haxelib/
             export/release/linux/haxe/
             export/release/linux/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing LibVLC
         run: |
           sudo apt-get install libvlc-dev libvlccore-dev
@@ -91,7 +93,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -101,8 +103,6 @@ jobs:
             .haxelib/
             export/debug/linux/haxe/
             export/debug/linux/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing LibVLC
         run: |
           sudo apt-get install libvlc-dev libvlccore-dev

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  HAXE_VERSION: 4.3.7
+  HXCPP_COMPILE_CACHE: ${{ github.workspace }}/.hxcpp_cache
+
 jobs:
   build:
     name: Mac OS Build
@@ -17,7 +21,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -27,8 +31,6 @@ jobs:
             .haxelib/
             export/release/macos/haxe/
             export/release/macos/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing/Updating libraries
         run: |
           haxe -cp commandline -D analyzer-optimize --run Main setup -s
@@ -88,7 +90,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -98,8 +100,6 @@ jobs:
             .haxelib/
             export/debug/macos/haxe/
             export/debug/macos/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing/Updating libraries
         run: |
           haxe -cp commandline -D analyzer-optimize --run Main setup -s

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  HAXE_VERSION: 4.3.7
+  HXCPP_COMPILE_CACHE: ${{ github.workspace }}/.hxcpp_cache
+
 jobs:
   build:
     name: Windows Build
@@ -17,7 +21,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -27,8 +31,6 @@ jobs:
             .haxelib/
             export/release/windows/haxe/
             export/release/windows/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing/Updating libraries
         run: |
           haxe -cp commandline -D analyzer-optimize --run Main setup -s --no-vscheck
@@ -86,7 +88,7 @@ jobs:
       - name: Setting up Haxe
         uses: krdlab/setup-haxe@v2
         with:
-          haxe-version: 4.3.7
+          haxe-version: ${{ env.HAXE_VERSION }}
       - name: Restore existing build cache for faster compilation
         uses: actions/cache@v4.2.3
         with:
@@ -96,8 +98,6 @@ jobs:
             .haxelib/
             export/debug/windows/haxe/
             export/debug/windows/obj/
-      - run: |
-          echo "HXCPP_COMPILE_CACHE=~/.hxcpp" >> $GITHUB_ENV
       - name: Installing/Updating libraries
         run: |
           haxe -cp commandline -D analyzer-optimize --run Main setup -s --no-vscheck


### PR DESCRIPTION
For adding `HAXE_VERSION` environment variable, y'all don't need to change the haxe version on both `release` and `debug` parts, instead y'all can  change the `HAXE_VERSION` to use a specific haxe version on both of them easily.

And for adding `HXCPP_COMPILE_CACHE` environment variable, this should make compilation a bit more faster(check https://github.com/openfl/lime/commit/8090bacdc6141c982a70dd8df381483829c04278 for more info about it)