### PR TITLE
Add a flag related to Icon Movement on the Healthbar

### DIFF
--- a/source/funkin/backend/system/Flags.hx
+++ b/source/funkin/backend/system/Flags.hx
@@ -106,7 +106,7 @@ class Flags {
 	public static var DEFAULT_BEATS_PER_MEASURE:Int = 4;
 	public static var DEFAULT_STEPS_PER_BEAT:Int = 4;
 	public static var DEFAULT_LOOP_TIME:Float = 0.0;
-
+	public static var ICONS_AUTOPOSITION:Bool = true;
 	public static var SUPPORTED_CHART_RUNTIME_FORMATS:Array<String> = ["Legacy", "Psych Engine"];
 	public static var SUPPORTED_CHART_FORMATS:Array<String> = ["BaseGame"];
 

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -943,7 +943,7 @@ class PlayState extends MusicBeatState
 
 		// Make icons appear in the correct spot during cutscenes
 		healthBar.update(0);
-		if (updateIconPositions != null)
+		if (updateIconPositions != null && Flags.ICONS_AUTOPOSITION)
 			updateIconPositions();
 
 		__updateNote_event = EventManager.get(NoteUpdateEvent);


### PR DESCRIPTION
so i feel that its kinda dumb rn how you have to like kill the function and it just doesnt work sometimes, so this PR Adds a flag for cancelling the movement automatically