### PR TITLE
Update macOS from 14 to 15 in the workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: Mac OS Build
     permissions: write-all
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Pulling the new commit
         uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
   debug_build:
     name: Mac OS Debug Build
     permissions: write-all
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
     steps:
       - name: Pulling the new commit


### PR DESCRIPTION
Reason: macOS 14 will be removed from Github in 2nd November 2026.

I tested it out in the workflow and it works fine.