### PR TITLE
fix down/negative scroll again Hopefully

### DIFF
--- a/source/funkin/game/Note.hx
+++ b/source/funkin/game/Note.hx
@@ -229,7 +229,7 @@ class Note extends FlxSprite
 		return v;
 	}
 	inline function get_useAntialiasingFix() {
-		return gapFix>0;
+		return gapFix > 0;
 	}
 
 	/**
@@ -288,14 +288,15 @@ class Note extends FlxSprite
 
 	@:noCompletion @:dox(hide) override function isOnScreen(?camera:FlxCamera):Bool {
 		var downscrollCam = (Std.isOfType(camera, HudCamera) ? cast(camera, HudCamera).downscroll : false);
-
+		if (updateFlipY) {
+			flipY = (isSustainNote && flipSustain) && (downscrollCam != (lastScrollSpeed < 0));
+		}
 		if (downscrollCam == __lastDownscrollCam)
 			return super.isOnScreen(camera);
 		else
 			__lastX = x;
 
-		if (updateFlipY) flipY = (isSustainNote && flipSustain) && (downscrollCam != (__strum != null && __strum.getScrollSpeed(this) < 0));
-		if (downscrollCam && __strum != null) {
+		if (downscrollCam && __strum != null && __strum.updateNotesPosX && updateNotesPosX) {
 			x = -x + 2 * (__strum.x - origin.x + offset.x) + __strum.width;
 		}
 		final isOnScreen = super.isOnScreen(camera);
@@ -312,7 +313,7 @@ class Note extends FlxSprite
 	}
 
 	public function isOnScreenOriginal(?camera:FlxCamera):Bool {
-    return super.isOnScreen(camera);
+    	return super.isOnScreen(camera);
 	}
 
 	public var earlyPressWindow:Float = Flags.EARLY_HIT_WINDOW_RANGE;
@@ -324,7 +325,7 @@ class Note extends FlxSprite
 		if (lastScrollSpeed != scrollSpeed) {
 			lastScrollSpeed = scrollSpeed;
 			if (nextSustain != null) {
-				scale.y = (sustainLength * 0.45 * scrollSpeed) / frameHeight;
+				scale.y = (sustainLength * 0.45 * Math.abs(scrollSpeed)) / frameHeight;
 				updateHitbox();
 				scale.y += gapFix / frameHeight;
 			}
@@ -334,7 +335,7 @@ class Note extends FlxSprite
 	}
 
 	public function updateSustainClip() if (wasGoodHit && !noSustainClip) {
-		var t = CoolUtil.bound((Conductor.songPosition - strumTime) / height * 0.45 * lastScrollSpeed, 0, 1);
+		var t = CoolUtil.bound((Conductor.songPosition - strumTime) / height * 0.45 * Math.abs(lastScrollSpeed), 0, 1);
 		@:bypassAccessor {
 			if (clipRect == null) clipRect = FlxRect.get();
 			clipRect.set(0, frameHeight * t, frameWidth, frameHeight * (1 - t));


### PR DESCRIPTION
few things were missing that bugged stuff out:

- downscroll would cause (manually x-moved) notes to spaz out each frame (pausing included) if their updateNotesPosX was false
- negative scroll speed now updates correctly , previous version would kinda either delay the sustain flip or not function at all due to being blocked by a return early