### PR TITLE
Use `release` ndlls instead of the `debug` ones for debug builds and a proper Mac OS Universal support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,20 +64,6 @@ jobs:
         with:
           name: Codename Engine
           path: export/release/linux/bin/
-      - name: Building the game (debug build)
-        run: haxelib run lime build linux -debug -DCOMPILE_EXPERIMENTAL
-      # - name: Tar files (debug build)
-      #   run: tar -zcvf CodenameEngineDebug.tar.gz -C export/debug/linux/bin .
-      - name: Uploading artifact (executable)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug (Executable Only)
-          path: export/debug/linux/bin/CodenameEngine
-      - name: Uploading artifact (entire debug build)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug
-          path: export/debug/linux/bin/
       # - name: Clearing already existing cache
       #   uses: actions/github-script@v6
       #   with:
@@ -105,3 +91,81 @@ jobs:
       #     path: |
       #       .haxelib/
       #       export/release/linux/obj/
+
+# didnt compile debug in the same job or github would have said that job wasn't completed until debug was done too (debug uploads are not essential)
+  debug_build:
+    name: Linux Debug Build
+    permissions: write-all
+    runs-on: ubuntu-24.04
+    needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
+    steps:
+      - name: Pulling the new commit
+        uses: actions/checkout@v6
+      - name: Setting up Haxe
+        uses: krdlab/setup-haxe@v2
+        with:
+          haxe-version: ${{ env.HAXE_VERSION }}
+      # - name: Restore existing build cache for faster compilation
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # not caching the bin folder to prevent asset duplication and stuff like that
+      #     key: cache-build-linux-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/linux/obj/
+      - name: Installing Packages for Building Lime (TEMPORARY)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qq \
+          libegl1-mesa-dev libgl1-mesa-dev libibus-1.0-dev libdbus-1-dev libdecor-0-dev libudev-dev libgbm-dev libdrm-dev \
+          libpng-dev libturbojpeg-dev libvorbis-dev libopenal-dev libsdl2-dev libglu1-mesa-dev libmbedtls-dev libuv1-dev libsqlite3-dev \
+          libx11-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbcommon-dev libxcursor-dev libxrandr-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxxf86vm-dev \
+          libpulse-dev libasound2-dev libpipewire-0.3-dev \
+          zlib1g-dev
+      - name: Installing LibVLC
+        run: |
+          sudo apt-get install libvlc-dev libvlccore-dev
+      - name: Installing/Updating libraries
+        run: |
+          haxe -cp commandline -D analyzer-optimize --run Main setup -si
+      - name: Building the game
+        run: |
+          haxelib run lime setup -alias -y -nocffi
+          haxelib run lime rebuild hxcpp
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild linux -nocolor -release
+          haxelib run lime build linux -debug -DCOMPILE_EXPERIMENTAL
+      # - name: Tar files
+      #   run: tar -zcvf CodenameEngine.tar.gz -C export/debug/linux/bin .
+      - name: Uploading artifact (entire build)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine Debug
+          path: export/debug/linux/bin/
+      # - name: Clearing already existing cache
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const caches = await github.rest.actions.getActionsCacheList({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #       })
+      #       for (const cache of caches.data.actions_caches) {
+      #         if (cache.key == "cache-build-linux-debug") {
+      #           console.log('Clearing ' + cache.key + '...')
+      #           await github.rest.actions.deleteActionsCacheById({
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             cache_id: cache.id,
+      #           })
+      #           console.log("Cache cleared.")
+      #         }
+      #       }
+      # - name: Uploading new cache
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # caching again since for some reason it doesnt work with the first post cache shit
+      #     key: cache-build-linux-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/linux/obj/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ env:
   HXCPP_COMPILE_CACHE: ${{ github.workspace }}/.hxcpp_cache
 
 jobs:
-  build:
-    name: Mac OS Build
+  intel_build:
+    name: Mac OS x64 Build
     permissions: write-all
     runs-on: macos-26
     steps:
@@ -32,27 +32,23 @@ jobs:
       #       export/release/macos/obj/
       - name: Installing/Updating libraries
         run: |
-          brew untap aws/tap
-          brew install zlib
+          brew trust aws/tap
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+          arch -x86_64 /usr/local/bin/brew install zlib
           haxe -cp commandline -D analyzer-optimize --run Main setup -si
       - name: Building the game
         run: |
           haxelib run lime setup -alias -y -nocffi
           haxelib run lime rebuild hxcpp
           haxelib run lime rebuild tools
-          haxelib run lime rebuild mac -nocolor -release
-          haxelib run lime build mac -DCOMPILE_EXPERIMENTAL
+          haxelib run lime rebuild mac -64 -nocolor -release
+          arch -x86_64 haxelib run lime build mac -DCOMPILE_EXPERIMENTAL
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
-      - name: Uploading artifact (executable)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine (Executable Only)
-          path: export/release/macos/bin/CodenameEngine.app/Contents/MacOS/CodenameEngine
       - name: Uploading artifact (entire build)
         uses: actions/upload-artifact@v7
         with:
-          name: Codename Engine
+          name: Codename Engine-x64
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
       #   uses: actions/github-script@v6
@@ -82,12 +78,126 @@ jobs:
       #       .haxelib/
       #       export/release/macos/obj/
 
-# didnt compile debug in the same job or github would have said that job wasn't completed until debug was done too (debug uploads are not essential)
-  debug_build:
-    name: Mac OS Debug Build
+  arm_build:
+    name: Mac OS ARM64 Build
     permissions: write-all
     runs-on: macos-26
-    needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
+    steps:
+      - name: Pulling the new commit
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setting up Haxe
+        uses: krdlab/setup-haxe@v2
+        with:
+          haxe-version: ${{ env.HAXE_VERSION }}
+      # - name: Restore existing build cache for faster compilation
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # not caching the bin folder to prevent asset duplication and stuff like that
+      #     key: cache-build-mac
+      #     path: |
+      #       .haxelib/
+      #       export/release/macos/obj/
+      - name: Installing/Updating libraries
+        run: |
+          brew trust aws/tap
+          brew install zlib
+          haxe -cp commandline -D analyzer-optimize --run Main setup -si
+      - name: Building the game
+        run: |
+          haxelib run lime setup -alias -y -nocffi
+          haxelib run lime rebuild hxcpp
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild mac -nocolor -release
+          haxelib run lime build mac -DCOMPILE_EXPERIMENTAL
+      - name: Tar files
+        run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
+      - name: Uploading artifact (entire build)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine-ARM64
+          path: CodenameEngine.tar.gz
+      # - name: Clearing already existing cache
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const caches = await github.rest.actions.getActionsCacheList({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #       })
+      #       for (const cache of caches.data.actions_caches) {
+      #         if (cache.key == "cache-build-mac") {
+      #           console.log('Clearing ' + cache.key + '...')
+      #           await github.rest.actions.deleteActionsCacheById({
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             cache_id: cache.id,
+      #           })
+      #           console.log("Cache cleared.")
+      #         }
+      #       }
+      # - name: Uploading new cache
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # caching again since for some reason it doesnt work with the first post cache shit
+      #     key: cache-build-mac
+      #     path: |
+      #       .haxelib/
+      #       export/release/macos/obj/
+
+  universal_build:
+    name: Mac OS Universal Build
+    permissions: write-all
+    runs-on: macos-26
+    needs: 
+      - intel_build
+      - arm_build
+    steps:
+      - name: Download Mac OS x64 Full Build
+        uses: actions/download-artifact@v8
+        with:
+          name: Codename Engine-x64
+          path: intel
+      - name: Download Mac OS ARM64 Full Build
+        uses: actions/download-artifact@v8
+        with:
+          name: Codename Engine-ARM64
+          path: arm
+      - name: Tar files (x64)
+        run: tar -xvf intel/CodenameEngine.tar.gz -C intel
+      - name: Tar files (ARM64)
+        run: tar -xvf arm/CodenameEngine.tar.gz -C arm
+      - name: Removing ARM64 and x64 artifacts
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: Codename Engine-*
+      - name: Creating Universal App Bundle
+        shell: bash
+        run: |
+          BIN="CodenameEngine.app/Contents/MacOS"
+          INTEL="intel/CodenameEngine.app/Contents/MacOS"
+          ARM="arm/CodenameEngine.app/Contents/MacOS"
+          cp -R intel/CodenameEngine.app CodenameEngine.app
+          lipo -create "$INTEL/CodenameEngine" "$ARM/CodenameEngine" -output "$BIN/CodenameEngine"
+          lipo -create "$INTEL/lime.ndll" "$ARM/lime.ndll" -output "$BIN/lime.ndll"
+      - name: Uploading Universal Mac OS bundle (executable)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine (Executable Only)
+          path: CodenameEngine.app/Contents/MacOS/CodenameEngine
+      - name: Uploading Universal Mac OS bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine
+          path: CodenameEngine.app
+
+# didnt compile debug in the same job or github would have said that job wasn't completed until debug was done too (debug uploads are not essential)
+  intel_debug_build:
+    name: Mac OS x64 Debug Build
+    permissions: write-all
+    runs-on: macos-26
+    needs: universal_build # since its low priority, it'll run after, so actions will concentrate first on normal builds
     steps:
       - name: Pulling the new commit
         uses: actions/checkout@v6
@@ -105,22 +215,23 @@ jobs:
       #       export/debug/macos/obj/
       - name: Installing/Updating libraries
         run: |
-          brew untap aws/tap
-          brew install zlib
+          brew trust aws/tap
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+          arch -x86_64 /usr/local/bin/brew install zlib
           haxe -cp commandline -D analyzer-optimize --run Main setup -si
       - name: Building the game
         run: |
           haxelib run lime setup -alias -y -nocffi
           haxelib run lime rebuild hxcpp
           haxelib run lime rebuild tools
-          haxelib run lime rebuild mac -nocolor -release
-          haxelib run lime build mac -debug -DCOMPILE_EXPERIMENTAL
+          haxelib run lime rebuild mac -64 -nocolor -release
+          arch -x86_64 haxelib run lime build mac -debug -DCOMPILE_EXPERIMENTAL
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/debug/macos/bin .
       - name: Uploading artifact (entire build)
         uses: actions/upload-artifact@v7
         with:
-          name: Codename Engine Debug
+          name: Codename Engine-x64 Debug
           path: CodenameEngine.tar.gz
       # - name: Clearing already existing cache
       #   uses: actions/github-script@v6
@@ -149,3 +260,112 @@ jobs:
       #     path: |
       #       .haxelib/
       #       export/debug/macos/obj/
+
+  arm_debug_build:
+    name: Mac OS ARM64 Debug Build
+    permissions: write-all
+    runs-on: macos-26
+    needs: universal_build # since its low priority, it'll run after, so actions will concentrate first on normal builds
+    steps:
+      - name: Pulling the new commit
+        uses: actions/checkout@v6
+      - name: Setting up Haxe
+        uses: krdlab/setup-haxe@v2
+        with:
+          haxe-version: ${{ env.HAXE_VERSION }}
+      # - name: Restore existing build cache for faster compilation
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # not caching the bin folder to prevent asset duplication and stuff like that
+      #     key: cache-build-mac-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/macos/obj/
+      - name: Installing/Updating libraries
+        run: |
+          brew trust aws/tap
+          brew install zlib
+          haxe -cp commandline -D analyzer-optimize --run Main setup -si
+      - name: Building the game
+        run: |
+          haxelib run lime setup -alias -y -nocffi
+          haxelib run lime rebuild hxcpp
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild mac -nocolor -release
+          haxelib run lime build mac -debug -DCOMPILE_EXPERIMENTAL
+      - name: Tar files
+        run: tar -zcvf CodenameEngine.tar.gz -C export/debug/macos/bin .
+      - name: Uploading artifact (entire build)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine-ARM64 Debug
+          path: CodenameEngine.tar.gz
+      # - name: Clearing already existing cache
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const caches = await github.rest.actions.getActionsCacheList({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #       })
+      #       for (const cache of caches.data.actions_caches) {
+      #         if (cache.key == "cache-build-mac-debug") {
+      #           console.log('Clearing ' + cache.key + '...')
+      #           await github.rest.actions.deleteActionsCacheById({
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             cache_id: cache.id,
+      #           })
+      #           console.log("Cache cleared.")
+      #         }
+      #       }
+      # - name: Uploading new cache
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # caching again since for some reason it doesnt work with the first post cache shit
+      #     key: cache-build-mac-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/macos/obj/
+
+  universal_debug_build:
+    name: Mac OS Universal Debug Build
+    permissions: write-all
+    runs-on: macos-26
+    needs: 
+      - intel_debug_build
+      - arm_debug_build
+    steps:
+      - name: Download Mac OS x64 Full Build
+        uses: actions/download-artifact@v8
+        with:
+          name: Codename Engine-x64 Debug
+          path: intel
+      - name: Download Mac OS ARM64 Full Build
+        uses: actions/download-artifact@v8
+        with:
+          name: Codename Engine-ARM64 Debug
+          path: arm
+      - name: Tar files (x64)
+        run: tar -xvf intel/CodenameEngine.tar.gz -C intel
+      - name: Tar files (ARM64)
+        run: tar -xvf arm/CodenameEngine.tar.gz -C arm
+      - name: Removing ARM64 and x64 artifacts
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: Codename Engine-*
+      - name: Creating Universal App Bundle
+        shell: bash
+        run: |
+          BIN="CodenameEngine.app/Contents/MacOS"
+          INTEL="intel/CodenameEngine.app/Contents/MacOS"
+          ARM="arm/CodenameEngine.app/Contents/MacOS"
+          cp -R intel/CodenameEngine.app CodenameEngine.app
+          lipo -create "$INTEL/CodenameEngine" "$ARM/CodenameEngine" -output "$BIN/CodenameEngine"
+          lipo -create "$INTEL/lime.ndll" "$ARM/lime.ndll" -output "$BIN/lime.ndll"
+      - name: Uploading Universal Mac OS bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine Debug
+          path: CodenameEngine.app
+

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
           haxelib run lime setup -alias -y -nocffi
           haxelib run lime rebuild hxcpp
           haxelib run lime rebuild tools
-          haxelib run lime rebuild mac -nocolor
+          haxelib run lime rebuild mac -nocolor -release
           haxelib run lime build mac -DCOMPILE_EXPERIMENTAL
       - name: Tar files
         run: tar -zcvf CodenameEngine.tar.gz -C export/release/macos/bin .
@@ -54,20 +54,6 @@ jobs:
         with:
           name: Codename Engine
           path: CodenameEngine.tar.gz
-      - name: Building the game (debug build)
-        run: haxelib run lime build mac -debug -DCOMPILE_EXPERIMENTAL
-      - name: Tar files (debug build)
-        run: tar -zcvf CodenameEngineDebug.tar.gz -C export/debug/macos/bin .
-      - name: Uploading artifact (debug executable)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug (Executable Only)
-          path: export/debug/macos/bin/CodenameEngine.app/Contents/MacOS/CodenameEngine
-      - name: Uploading artifact (entire debug build)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug
-          path: CodenameEngineDebug.tar.gz
       # - name: Clearing already existing cache
       #   uses: actions/github-script@v6
       #   with:
@@ -95,3 +81,71 @@ jobs:
       #     path: |
       #       .haxelib/
       #       export/release/macos/obj/
+
+# didnt compile debug in the same job or github would have said that job wasn't completed until debug was done too (debug uploads are not essential)
+  debug_build:
+    name: Mac OS Debug Build
+    permissions: write-all
+    runs-on: macos-26
+    needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
+    steps:
+      - name: Pulling the new commit
+        uses: actions/checkout@v6
+      - name: Setting up Haxe
+        uses: krdlab/setup-haxe@v2
+        with:
+          haxe-version: ${{ env.HAXE_VERSION }}
+      # - name: Restore existing build cache for faster compilation
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # not caching the bin folder to prevent asset duplication and stuff like that
+      #     key: cache-build-mac-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/macos/obj/
+      - name: Installing/Updating libraries
+        run: |
+          brew untap aws/tap
+          brew install zlib
+          haxe -cp commandline -D analyzer-optimize --run Main setup -si
+      - name: Building the game
+        run: |
+          haxelib run lime setup -alias -y -nocffi
+          haxelib run lime rebuild hxcpp
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild mac -nocolor -release
+          haxelib run lime build mac -debug -DCOMPILE_EXPERIMENTAL
+      - name: Tar files
+        run: tar -zcvf CodenameEngine.tar.gz -C export/debug/macos/bin .
+      - name: Uploading artifact (entire build)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine Debug
+          path: CodenameEngine.tar.gz
+      # - name: Clearing already existing cache
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const caches = await github.rest.actions.getActionsCacheList({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #       })
+      #       for (const cache of caches.data.actions_caches) {
+      #         if (cache.key == "cache-build-mac-debug") {
+      #           console.log('Clearing ' + cache.key + '...')
+      #           await github.rest.actions.deleteActionsCacheById({
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             cache_id: cache.id,
+      #           })
+      #           console.log("Cache cleared.")
+      #         }
+      #       }
+      # - name: Uploading new cache
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # caching again since for some reason it doesnt work with the first post cache shit
+      #     key: cache-build-mac-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/macos/obj/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
           haxelib run lime setup -alias -y -nocffi
           haxelib run lime rebuild hxcpp
           haxelib run lime rebuild tools
-          haxelib run lime rebuild windows -nocolor
+          haxelib run lime rebuild windows -nocolor -release
           haxelib run lime build windows -DCOMPILE_EXPERIMENTAL
       - name: Uploading artifact (executable)
         uses: actions/upload-artifact@v7
@@ -52,20 +52,6 @@ jobs:
         with:
           name: Codename Engine
           path: export/release/windows/bin
-      - name: Building the game (debug build)
-        run: haxelib run lime build windows -debug -DCOMPILE_EXPERIMENTAL
-      - name: Uploading artifact (debug executable)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug (Executable Only)
-          path: |
-            export/debug/windows/bin/CodenameEngine.exe
-            export/debug/windows/bin/lime.ndll
-      - name: Uploading artifact (entire debug build)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Codename Engine Debug
-          path: export/debug/windows/bin
       # - name: Clearing already existing cache
       #   uses: actions/github-script@v6
       #   with:
@@ -93,3 +79,68 @@ jobs:
       #     path: |
       #       .haxelib/
       #       export/release/windows/obj/
+
+# didnt compile debug in the same job or github would have said that job wasn't completed until debug was done too (debug uploads are not essential)
+  debug_build:
+    name: Windows Debug Build
+    permissions: write-all
+    runs-on: windows-latest
+    needs: build # since its low priority, it'll run after, so actions will concentrate first on normal builds
+    steps:
+      - name: Pulling the new commit
+        uses: actions/checkout@v6
+      - name: Setting up Haxe
+        uses: krdlab/setup-haxe@v2
+        with:
+          haxe-version: ${{ env.HAXE_VERSION }}
+      # - name: Restore existing build cache for faster compilation
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # not caching the bin folder to prevent asset duplication and stuff like that
+      #     key: cache-build-windows-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/windows/haxe/
+      #       export/debug/windows/obj/
+      - name: Installing/Updating libraries
+        run: |
+          haxe -cp commandline -D analyzer-optimize --run Main setup -si --no-vscheck
+      - name: Building the game
+        run: |
+          haxelib run lime setup -alias -y -nocffi
+          haxelib run lime rebuild hxcpp
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild windows -nocolor -release
+          haxelib run lime build windows -debug
+      - name: Uploading artifact (entire build)
+        uses: actions/upload-artifact@v7
+        with:
+          name: Codename Engine Debug
+          path: export/debug/windows/bin
+      # - name: Clearing already existing cache
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const caches = await github.rest.actions.getActionsCacheList({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #       })
+      #       for (const cache of caches.data.actions_caches) {
+      #         if (cache.key == "cache-build-windows-debug") {
+      #           console.log('Clearing ' + cache.key + '...')
+      #           await github.rest.actions.deleteActionsCacheById({
+      #             owner: context.repo.owner,
+      #             repo: context.repo.repo,
+      #             cache_id: cache.id,
+      #           })
+      #           console.log("Cache cleared.")
+      #         }
+      #       }
+      # - name: Uploading new cache
+      #   uses: actions/cache@v4.2.3
+      #   with:
+      #     # caching again since for some reason it doesnt work with the first post cache shit
+      #     key: cache-build-windows-debug
+      #     path: |
+      #       .haxelib/
+      #       export/debug/windows/obj/

--- a/source/funkin/game/cutscenes/VideoCutscene.hx
+++ b/source/funkin/game/cutscenes/VideoCutscene.hx
@@ -25,7 +25,7 @@ class VideoCutscene extends Cutscene {
 	var localPath:String;
 
 	#if VIDEO_CUTSCENES
-	var video:FlxVideoSprite;
+	final video:FlxVideoSprite = new FlxVideoSprite();
 	final mutex = new sys.thread.Mutex();
 
 	var cutsceneCamera:FlxCamera;
@@ -58,7 +58,7 @@ class VideoCutscene extends Cutscene {
 
 		parseSubtitles();
 
-		add(video = new FlxVideoSprite());
+		add(video);
 		video.antialiasing = true;
 		video.bitmap.onEndReached.add(close);
 		video.bitmap.onFormatSetup.add(function() if (video.bitmap != null && video.bitmap.bitmapData != null) {


### PR DESCRIPTION
Redo of https://github.com/CodenameCrew/CodenameEngine/pull/1051 and https://github.com/CodenameCrew/CodenameEngine/pull/1049

Oh please no, don't waste my time for nothing without knowing how to fix my pr.
I'm begging you please.

New description:
Switched the ndlls from debug to release for debug builds, since it's trying to load the ndlls internally for the lime tools. I tested the debug build on Windows and it still looks okay.

I thought my pr https://github.com/CodenameCrew/CodenameEngine/pull/931 gonna bring Universal support for Mac, but I was wrong, instead it targets ARM, so the only way to bring Universal support for it is to build both Intel and ARM separately and then merge them together.