### PR TITLE
Add 'CLASSIC' ease to Camera Zoom event

### DIFF
--- a/source/funkin/backend/chart/EventsData.hx
+++ b/source/funkin/backend/chart/EventsData.hx
@@ -68,7 +68,7 @@ class EventsData {
 			{name: "Tween Time (Steps)", type: TFloat(0.25, 9999, 0.25, 2), defValue: 4},
 			{
 				name: "Tween Ease (ex: circ, quad, cube)",
-				type: TDropDown(['linear', 'back', 'bounce', 'circ', 'cube', 'elastic', 'expo', 'quad', 'quart', 'quint', 'sine', 'smoothStep', 'smootherStep']),
+				type: TDropDown(['linear', 'CLASSIC', 'back', 'bounce', 'circ', 'cube', 'elastic', 'expo', 'quad', 'quart', 'quint', 'sine', 'smoothStep', 'smootherStep']),
 				defValue: "linear"
 			},
 			{

--- a/source/funkin/backend/chart/EventsData.hx
+++ b/source/funkin/backend/chart/EventsData.hx
@@ -68,7 +68,7 @@ class EventsData {
 			{name: "Tween Time (Steps)", type: TFloat(0.25, 9999, 0.25, 2), defValue: 4},
 			{
 				name: "Tween Ease (ex: circ, quad, cube)",
-				type: TDropDown(['linear', 'CLASSIC', 'back', 'bounce', 'circ', 'cube', 'elastic', 'expo', 'quad', 'quart', 'quint', 'sine', 'smoothStep', 'smootherStep']),
+				type: TDropDown(['CLASSIC', 'linear', 'back', 'bounce', 'circ', 'cube', 'elastic', 'expo', 'quad', 'quart', 'quint', 'sine', 'smoothStep', 'smootherStep']),
 				defValue: "linear"
 			},
 			{

--- a/source/funkin/editors/charter/CharterEvent.hx
+++ b/source/funkin/editors/charter/CharterEvent.hx
@@ -309,7 +309,7 @@ class CharterEvent extends UISliceSprite implements ICharterSelectable {
 			case "Camera Zoom":
 				var shouldDoArrow:Bool = false;
 				if (event.params != null)
-					shouldDoArrow = event.params[0];
+					shouldDoArrow = event.params[0] && event.params[4] != "CLASSIC";
 
 				if(event.params != null && shouldDoArrow && !inMenu) {
 					var group = new EventIconGroup();

--- a/source/funkin/game/PlayState.hx
+++ b/source/funkin/game/PlayState.hx
@@ -1664,6 +1664,9 @@ class PlayState extends MusicBeatState
 					cam.zoom = finalZoom;
 					if (cam == camHUD) defaultHudZoom = finalZoom;
 					else defaultCamZoom = finalZoom;
+				} else if (event.params[4] == "CLASSIC") {
+					if (cam == camHUD) defaultHudZoom = finalZoom;
+					else defaultCamZoom = finalZoom;
 				} else
 					eventsTween.set(name, FlxTween.tween(cam, {zoom: finalZoom}, (Conductor.stepCrochet / 1000) * event.params[3], {ease: CoolUtil.flxeaseFromString(event.params[4], event.params[5]), onUpdate: function(_) {
 						if (cam == camHUD) defaultHudZoom = cam.zoom;


### PR DESCRIPTION
Adds a "CLASSIC" to the ease dropdown in the Camera Zoom event, which only sets the default camera's zoom without snapping or tweening it.

thanks blehtty for the free pr