### PR TITLE
Replace memoryPeak with actual process memory usage

### DIFF
--- a/assets/languages/en/Options.xml
+++ b/assets/languages/en/Options.xml
@@ -206,6 +206,9 @@
 
 		<str id="songOffsetAffectEditors-name">Offset in Charter</str>
 		<str id="songOffsetAffectEditors-desc">If checked, this will enable the Song Offset option in the Chart Editor too.</str>
+
+		<str id="legacyMemoryCounter-name">Legacy Memory Counter</str>
+		<str id="legacyMemoryCounter-desc">If checked, the memory counter will show the Haxe GC memory usage and its peak (the original behavior) instead of the working set memory seen in Task Manager.</str>
 	</group>
 
 </language>

--- a/assets/languages/es/Options.xml
+++ b/assets/languages/es/Options.xml
@@ -180,6 +180,9 @@
 		<str id="charterAutoSaveWarningTime-desc">Esto controla por cuánto tiempo te advertirá el editor antes de autoguardar (en segundos..., 0 para desactivar)</str>
 
 		<str id="charterAutoSavesSeparateFolder-name">Carpeta de Autoguardados</str>
-		<str id="charterAutoSavesSeparateFolder-desc">Si está activado, el autoguardado se guardará en otra carpeta con su fecha en vez de sobreescribir el archivo actual. (song/autosaves/)</str>	</group>
+		<str id="charterAutoSavesSeparateFolder-desc">Si está activado, el autoguardado se guardará en otra carpeta con su fecha en vez de sobreescribir el archivo actual. (song/autosaves/)</str>
+
+		<str id="legacyMemoryCounter-name">Contador de Memoria Clásico</str>
+		<str id="legacyMemoryCounter-desc">Si está activado, el contador de memoria mostrará el uso de memoria del GC de Haxe y su máximo (el comportamiento original) en vez de la memoria de trabajo vista en el Administrador de Tareas.</str>	</group>
 
 </language>

--- a/assets/languages/it/Options.xml
+++ b/assets/languages/it/Options.xml
@@ -199,5 +199,8 @@
 
 		<str id="songOffsetAffectEditors-name">Offset Editor Chart</str>
 		<str id="songOffsetAffectEditors-desc">Se abilitato, questo attiverà l'opzione Offset Canzone anche nel Editor Chart.</str>
+
+		<str id="legacyMemoryCounter-name">Contatore Memoria Classico</str>
+		<str id="legacyMemoryCounter-desc">Se attivato, il contatore di memoria mostrerà l'uso di memoria del GC di Haxe e il suo picco (il comportamento originale) invece della memoria di lavoro vista nel Task Manager.</str>
 	</group>
 </language>

--- a/assets/languages/pl/Options.xml
+++ b/assets/languages/pl/Options.xml
@@ -175,6 +175,9 @@
 
 		<str id="charterAutoSavesSeparateFolder-name">Folder Autozapisów</str>
 		<str id="charterAutoSavesSeparateFolder-desc">Jeśli włączone, Edytor będzie zapisywać pliki w osobnym folderze, zamiast nadpisywania aktualnego pliku. (song/autosaves/)</str>
+
+		<str id="legacyMemoryCounter-name">Klasyczny Licznik Pamięci</str>
+		<str id="legacyMemoryCounter-desc">Jeśli włączone, licznik pamięci pokaże użycie pamięci GC Haxe i jego szczyt (oryginalne zachowanie) zamiast pamięci roboczej widocznej w Menedżerze Zadań.</str>
 	</group>
 
 </language>

--- a/assets/languages/pt/Options.xml
+++ b/assets/languages/pt/Options.xml
@@ -206,6 +206,9 @@
 
 		<str id="songOffsetAffectEditors-name">Atraso no Mapeador</str>
 		<str id="songOffsetAffectEditors-desc">Se marcado, irá ativar o Atraso da Música no Editor de Mapas, também.</str>
+
+		<str id="legacyMemoryCounter-name">Contador de Memória Clássico</str>
+		<str id="legacyMemoryCounter-desc">Se marcado, o contador de memória mostrará o uso de memória do GC de Haxe e o seu máximo (o comportamento original) em vez da memória de trabalho vista no Gerenciador de Tarefas.</str>
 	</group>
 
 </language>

--- a/source/funkin/backend/system/framerate/MemoryCounter.hx
+++ b/source/funkin/backend/system/framerate/MemoryCounter.hx
@@ -8,8 +8,8 @@ class MemoryCounter extends Sprite {
 	public var memoryText:TextField;
 	public var memoryPeakText:TextField;
 
-	public var gcMemory:Float = 0;
-	public var processMemory:Float = 0;
+	public var memory:Float = 0;
+	public var memoryPeak:Float = 0;
 
 	public function new() {
 		super();
@@ -43,25 +43,25 @@ class MemoryCounter extends Sprite {
 		final gcMem = MemoryUtil.currentMemUsage();
 		final osMem = MemoryUtil.currentProcessMemUsage();
 
-		if (gcMem == gcMemory && osMem == processMemory) {
+		if (gcMem == memory && osMem == memoryPeak) {
 			updateLabelPosition();
 			return;
 		}
 
-		gcMemory = gcMem;
-		processMemory = osMem;
+		memory = gcMem;
+		memoryPeak = osMem;
 
-		memoryText.text = CoolUtil.getSizeString(gcMemory);
+		memoryText.text = CoolUtil.getSizeString(gcMem);
 		memoryPeakText.text = ' / ${CoolUtil.getSizeString(osMem)}';
 		#else
 		final mem = MemoryUtil.currentMemUsage();
 
-		if (mem == gcMemory) {
+		if (mem == memory) {
 			updateLabelPosition();
 			return;
 		}
 
-		gcMemory = mem;
+		memory = mem;
 		memoryText.text = CoolUtil.getSizeString(mem);
 		#end
 

--- a/source/funkin/backend/system/framerate/MemoryCounter.hx
+++ b/source/funkin/backend/system/framerate/MemoryCounter.hx
@@ -35,24 +35,49 @@ class MemoryCounter extends Sprite {
 
 	public function reload() {}
 
+	private var usingLegacy:Bool = false;
+
 	public override function __enterFrame(t:Int) {
 		if (alpha <= 0.05) return;
 		super.__enterFrame(t);
 
 		#if (cpp && (windows || mac || linux))
-		final gcMem = MemoryUtil.currentMemUsage();
-		final osMem = MemoryUtil.currentProcessMemUsage();
+		var legacy = funkin.options.Options.legacyMemoryCounter;
 
-		if (gcMem == memory && osMem == memoryPeak) {
-			updateLabelPosition();
-			return;
+		if (legacy) {
+			if (legacy != usingLegacy) {
+				usingLegacy = legacy;
+				memoryPeak = 0;
+			}
+
+			final mem = MemoryUtil.currentMemUsage();
+			if (memoryPeak < mem) memoryPeak = mem;
+			if (mem == memory) {
+				updateLabelPosition();
+				return;
+			}
+
+			memory = mem;
+			memoryPeakText.visible = true;
+			memoryText.text = CoolUtil.getSizeString(memory);
+			memoryPeakText.text = ' / ${CoolUtil.getSizeString(memoryPeak)}';
+		} else {
+			if (legacy != usingLegacy) usingLegacy = legacy;
+
+			final gcMem = MemoryUtil.currentMemUsage();
+			final osMem = MemoryUtil.currentProcessMemUsage();
+
+			if (gcMem == memory && osMem == memoryPeak) {
+				updateLabelPosition();
+				return;
+			}
+
+			memory = gcMem;
+			memoryPeak = osMem;
+			memoryPeakText.visible = true;
+			memoryText.text = CoolUtil.getSizeString(gcMem);
+			memoryPeakText.text = ' / ${CoolUtil.getSizeString(osMem)}';
 		}
-
-		memory = gcMem;
-		memoryPeak = osMem;
-
-		memoryText.text = CoolUtil.getSizeString(gcMem);
-		memoryPeakText.text = ' / ${CoolUtil.getSizeString(osMem)}';
 		#else
 		final mem = MemoryUtil.currentMemUsage();
 

--- a/source/funkin/backend/system/framerate/MemoryCounter.hx
+++ b/source/funkin/backend/system/framerate/MemoryCounter.hx
@@ -8,8 +8,8 @@ class MemoryCounter extends Sprite {
 	public var memoryText:TextField;
 	public var memoryPeakText:TextField;
 
-	public var memory:Float = 0;
-	public var memoryPeak:Float = 0;
+	public var gcMemory:Float = 0;
+	public var processMemory:Float = 0;
 
 	public function new() {
 		super();
@@ -28,6 +28,9 @@ class MemoryCounter extends Sprite {
 			addChild(label);
 		}
 		memoryPeakText.alpha = 0.5;
+		#if !(cpp && (windows || mac || linux))
+		memoryPeakText.visible = false;
+		#end
 	}
 
 	public function reload() {}
@@ -36,17 +39,31 @@ class MemoryCounter extends Sprite {
 		if (alpha <= 0.05) return;
 		super.__enterFrame(t);
 
-		final mem = MemoryUtil.currentMemUsage();
+		#if (cpp && (windows || mac || linux))
+		final gcMem = MemoryUtil.currentMemUsage();
+		final osMem = MemoryUtil.currentProcessMemUsage();
 
-		if (mem == memory) {
+		if (gcMem == gcMemory && osMem == processMemory) {
 			updateLabelPosition();
 			return;
 		}
 
-		memory = mem;
-		if (memoryPeak < memory) memoryPeak = memory;
-		memoryText.text = CoolUtil.getSizeString(memory);
-		memoryPeakText.text = ' / ${CoolUtil.getSizeString(memoryPeak)}';
+		gcMemory = gcMem;
+		processMemory = osMem;
+
+		memoryText.text = CoolUtil.getSizeString(gcMemory);
+		memoryPeakText.text = ' / ${CoolUtil.getSizeString(osMem)}';
+		#else
+		final mem = MemoryUtil.currentMemUsage();
+
+		if (mem == gcMemory) {
+			updateLabelPosition();
+			return;
+		}
+
+		gcMemory = mem;
+		memoryText.text = CoolUtil.getSizeString(mem);
+		#end
 
 		updateLabelPosition();
 	}

--- a/source/funkin/backend/utils/MemoryUtil.hx
+++ b/source/funkin/backend/utils/MemoryUtil.hx
@@ -119,6 +119,23 @@ final class MemoryUtil {
 		#end
 	}
 
+	/**
+	 * Gets the current process memory usage (Working Set / RSS) from the OS.
+	 * This is much more granular than Haxe GC memory and updates more frequently.
+	 * Returns the value in bytes, matching what you see in Task Manager / Activity Monitor.
+	 */
+	public static inline function currentProcessMemUsage():Float {
+		#if (cpp && windows)
+		return funkin.backend.utils.native.Windows.getCurrentProcessMemory();
+		#elseif (cpp && mac)
+		return funkin.backend.utils.native.Mac.getCurrentProcessMemory();
+		#elseif (cpp && linux)
+		return funkin.backend.utils.native.Linux.getCurrentProcessMemory();
+		#else
+		return currentMemUsage();
+		#end
+	}
+
 
 	/**
 	 * Gets the memory type of the system.

--- a/source/funkin/backend/utils/native/Linux.hx
+++ b/source/funkin/backend/utils/native/Linux.hx
@@ -1,7 +1,7 @@
 package funkin.backend.utils.native;
 
 #if linux
-@:cppFileCode("#include <stdio.h>")
+@:cppFileCode("#include <stdio.h>\n#include <time.h>")
 @:dox(hide)
 final class Linux {
 	@:functionCode('
@@ -30,20 +30,33 @@ final class Linux {
 	}
 
 	@:functionCode('
-		FILE *status = fopen("/proc/self/status", "r");
-		if (status == NULL) return 0.0;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	long long nowMs = now.tv_sec * 1000LL + now.tv_nsec / 1000000LL;
 
-		char line[256];
-		while (fgets(line, sizeof(line), status)) {
-			long rss;
-			if (sscanf(line, "VmRSS: %ld kB", &rss) == 1) {
-				fclose(status);
-				return (double)(rss * 1024); // kB -> bytes
-			}
+	// cache the value and only re-read /proc every 500ms, to avoid polling the kernel file every frame
+	static long long lastReadMs = 0;
+	static double cached = 0.0;
+
+	if (cached != 0.0 && (nowMs - lastReadMs) < 500)
+		return cached;
+
+	lastReadMs = nowMs;
+
+	FILE *status = fopen("/proc/self/status", "r");
+	if (status == NULL) return cached;
+
+	char line[256];
+	while (fgets(line, sizeof(line), status)) {
+		unsigned long long rss; // use 64-bit so the kB -> bytes conversion never overflows on 32-bit builds
+		if (sscanf(line, "VmRSS: %llu kB", &rss) == 1) {
+			fclose(status);
+			return cached = (double)rss * 1024.0; // kB -> bytes
 		}
-		fclose(status);
-		return 0.0;
-	')
+	}
+	fclose(status);
+	return cached;
+')
 	public static function getCurrentProcessMemory():Float
 	{
 		return 0;

--- a/source/funkin/backend/utils/native/Linux.hx
+++ b/source/funkin/backend/utils/native/Linux.hx
@@ -28,5 +28,25 @@ final class Linux {
 	{
 		return 0;
 	}
+
+	@:functionCode('
+		FILE *status = fopen("/proc/self/status", "r");
+		if (status == NULL) return 0.0;
+
+		char line[256];
+		while (fgets(line, sizeof(line), status)) {
+			long rss;
+			if (sscanf(line, "VmRSS: %ld kB", &rss) == 1) {
+				fclose(status);
+				return (double)(rss * 1024); // kB -> bytes
+			}
+		}
+		fclose(status);
+		return 0.0;
+	')
+	public static function getCurrentProcessMemory():Float
+	{
+		return 0;
+	}
 }
 #end

--- a/source/funkin/backend/utils/native/Mac.hx
+++ b/source/funkin/backend/utils/native/Mac.hx
@@ -5,6 +5,7 @@ import funkin.backend.utils.NativeAPI.CodeCursor;
 import openfl.ui.Mouse;
 
 @:headerInclude('sys/sysctl.h')
+@:headerInclude('mach/mach.h')
 @:dox(hide)
 final class Mac
 {
@@ -19,6 +20,19 @@ final class Mac
 	return value / 1024 / 1024;
 	')
 	public static function getTotalRam():Float
+	{
+		return 0;
+	}
+
+	@:functionCode('
+		task_basic_info_data_t info;
+		mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
+		if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &count) == KERN_SUCCESS) {
+			return (double)info.resident_size;
+		}
+		return 0.0;
+	')
+	public static function getCurrentProcessMemory():Float
 	{
 		return 0;
 	}

--- a/source/funkin/backend/utils/native/Windows.hx
+++ b/source/funkin/backend/utils/native/Windows.hx
@@ -27,6 +27,7 @@ import funkin.backend.utils.NativeAPI.MessageBoxIcon;
 #include <wingdi.h>
 #include <shellapi.h>
 #include <uxtheme.h>
+#include <psapi.h>
 
 #define SAFE_RELEASE(punk)  \\
 			  if ((punk) != NULL)  \\
@@ -264,6 +265,18 @@ final class Windows {
 		return (allocatedRAM / 1024);
 	")
 	public static function getTotalRam():Float
+	{
+		return 0;
+	}
+
+	@:functionCode("
+		PROCESS_MEMORY_COUNTERS_EX pmc;
+		if (GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc))) {
+			return (double)pmc.WorkingSetSize;
+		}
+		return 0.0;
+	")
+	public static function getCurrentProcessMemory():Float
 	{
 		return 0;
 	}

--- a/source/funkin/options/Options.hx
+++ b/source/funkin/options/Options.hx
@@ -38,6 +38,7 @@ class Options
 	public static var devMode:Bool = false;
 	public static var betaUpdates:Bool = false;
 	public static var splashesEnabled:Bool = true;
+	public static var legacyMemoryCounter:Bool = false;
 	@:dox(hide) @:doNotSave public static var hitWindow:Float = 250; // DEPRECATED
 	public static var songOffset:Float = 0;
 	public static var framerate:Int = 120;

--- a/source/funkin/options/categories/DebugOptions.hx
+++ b/source/funkin/options/categories/DebugOptions.hx
@@ -20,5 +20,8 @@ class DebugOptions extends TreeMenuScreen {
 		add(new NumOption(getNameID("charterAutoSaveWarningTime"), getDescID("charterAutoSaveWarningTime"), 0, 15, 1, "charterAutoSaveWarningTime"));
 		add(new Checkbox(getNameID("charterAutoSavesSeparateFolder"), getDescID("charterAutoSavesSeparateFolder"), "charterAutoSavesSeparateFolder"));
 		add(new Checkbox(getNameID("songOffsetAffectEditors"), getDescID("songOffsetAffectEditors"), "songOffsetAffectEditors"));
+		#if (cpp && (windows || mac || linux))
+		add(new Checkbox(getNameID("legacyMemoryCounter"), getDescID("legacyMemoryCounter"), "legacyMemoryCounter"));
+		#end
 	}
 }


### PR DESCRIPTION
Replace the second memoryPeak with the actual memory usage of the process as reported by the operating system. I believe this will be significantly more useful than the previous peak memory value. This works on Windows, macOS, and Linux. On non‑CPP targets or platforms other than these three, only a single memory number will be displayed, with the second one omitted.