### PR TITLE
add LimeAssets to Script imports

### DIFF
--- a/source/funkin/backend/scripting/Script.hx
+++ b/source/funkin/backend/scripting/Script.hx
@@ -51,6 +51,7 @@ class Script extends FlxBasic implements IFlxDestroyable {
 			// OpenFL & Lime related stuff
 			"BlendMode"			=> CoolUtil.getMacroAbstractClass("openfl.display.BlendMode"),
 			"Assets"			=> openfl.utils.Assets,
+			"LimeAssets"        => lime.utils.Assets,
 			"Application"		=> lime.app.Application,
 			"Main"				=> funkin.backend.system.Main,
 


### PR DESCRIPTION
This sucks and I don't like doing this this legitimately took me hours to figure out
<img width="1250" height="112" alt="image" src="https://github.com/user-attachments/assets/ed04a4ae-a1c0-4903-9eca-77dcfa0ea475" />

So I'm pleading that you add `LimeAssets` to the thing

Also please make `Assets.getBitmapData()` returning an `OptimizedBitmapData` be optional and like toggleable off in the function somehow or expose `image` somehow