### PR TITLE
Fix the inverted condition for USE_LEGACY_ZOOM_FACTOR

### DIFF
--- a/source/funkin/backend/FunkinSprite.hx
+++ b/source/funkin/backend/FunkinSprite.hx
@@ -215,15 +215,15 @@ class FunkinSprite extends FlxAnimate implements IBeatReceiver implements IOffse
 	private inline function __prepareZoomFactor(?rect:FlxRect, camera:FlxCamera):FlxRect {
 		if (Flags.USE_LEGACY_ZOOM_FACTOR)
 			return (rect ?? FlxRect.get()).set(
-				camera.width * 0.5,
-				camera.height * 0.5,
+				camera.width * 0.5 + camera.scroll.x * scrollFactor.x,
+				camera.height * 0.5 + camera.scroll.y * scrollFactor.y,
 				(camera.scaleX > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleX, 1, zoomFactor)),
 				(camera.scaleY > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleY, 1, zoomFactor))
 			);
 		else
 			return (rect ?? FlxRect.get()).set(
-				camera.width * 0.5 + camera.scroll.x * scrollFactor.x,
-				camera.height * 0.5 + camera.scroll.y * scrollFactor.y,
+				camera.width * 0.5,
+				camera.height * 0.5,
 				(camera.scaleX > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleX, 1, zoomFactor)),
 				(camera.scaleY > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleY, 1, zoomFactor))
 			);

--- a/source/funkin/backend/FunkinText.hx
+++ b/source/funkin/backend/FunkinText.hx
@@ -68,15 +68,15 @@ class FunkinText extends FlxText
     private inline function __prepareZoomFactor(rect:FlxRect, camera:FlxCamera):FlxRect {
 		if (Flags.USE_LEGACY_ZOOM_FACTOR)
 			return rect.set(
-				camera.width * 0.5,
-				camera.height * 0.5,
+				camera.width * 0.5 + camera.scroll.x * scrollFactor.x,
+				camera.height * 0.5 + camera.scroll.y * scrollFactor.y,
 				(camera.scaleX > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleX, 1, zoomFactor)),
 				(camera.scaleY > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleY, 1, zoomFactor))
 			);
 		else
 			return rect.set(
-				camera.width * 0.5 + camera.scroll.x * scrollFactor.x,
-				camera.height * 0.5 + camera.scroll.y * scrollFactor.y,
+				camera.width * 0.5,
+				camera.height * 0.5,
 				(camera.scaleX > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleX, 1, zoomFactor)),
 				(camera.scaleY > 0 ? Math.max : Math.min)(0, FlxMath.lerp(1 / camera.scaleY, 1, zoomFactor))
 			);


### PR DESCRIPTION
Fix the inverted condition for `USE_LEGACY_ZOOM_FACTOR`.
For nearly a year, the value set for `USE_LEGACY_ZOOM_FACTOR` has been correct, but the final code had the logic reversed. When `USE_LEGACY_ZOOM_FACTOR` was disabled, it actually used the 0.1.0 calculation method, while enabling it used the new one instead.