### PR TITLE
fix thorns scripted cutscene softlock

### DIFF
--- a/assets/songs/thorns/cutscene.hx
+++ b/assets/songs/thorns/cutscene.hx
@@ -53,7 +53,7 @@ function create() {
 			else {
 				timers.remove(swagTimer);
 				camHUD.visible = true;
-				self.startDialogue("assets/songs/" + PlayState.instance.SONG.meta.name.toLowerCase() + "/creepyDialogue.xml", self.close);
+				self.startDialogue("assets/songs/" + PlayState.SONG.meta.name.toLowerCase() + "/creepyDialogue.xml", self.close);
 			}
 		}));
 	});


### PR DESCRIPTION
Playstate.instance.SONG doesn't work anymore for some reason so it just locks up when loading the dialogue uh oh